### PR TITLE
GraphMLReader performance: batch transactions

### DIFF
--- a/src/main/java/com/tinkerpop/blueprints/pgm/parser/GraphMLReader.java
+++ b/src/main/java/com/tinkerpop/blueprints/pgm/parser/GraphMLReader.java
@@ -1,9 +1,11 @@
 package com.tinkerpop.blueprints.pgm.parser;
 
-
 import com.tinkerpop.blueprints.pgm.Edge;
 import com.tinkerpop.blueprints.pgm.Graph;
+import com.tinkerpop.blueprints.pgm.TransactionalGraph;
 import com.tinkerpop.blueprints.pgm.Vertex;
+import com.tinkerpop.blueprints.pgm.TransactionalGraph.Conclusion;
+import com.tinkerpop.blueprints.pgm.TransactionalGraph.Mode;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -18,110 +20,171 @@ import java.util.Map;
  */
 public class GraphMLReader {
 
-    public static void inputGraph(final Graph graph, final InputStream graphMLInputStream) throws XMLStreamException {
+	// TODO: experimental, can set higher than 1000 (RAM dependent)?
+	// Operations per transaction
+	private static final int TRANSACTION_BUFFER = 1000;
 
-        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-        XMLStreamReader reader = inputFactory.createXMLStreamReader(graphMLInputStream);
+	public static void inputGraph(final Graph graph,
+			final InputStream graphMLInputStream) throws XMLStreamException {
 
-        Map<String, String> keyIdMap = new HashMap<String, String>();
-        Map<String, String> keyTypesMaps = new HashMap<String, String>();
-        Map<String, Object> vertexIdMap = new HashMap<String, Object>();
+		XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+		XMLStreamReader reader = inputFactory
+				.createXMLStreamReader(graphMLInputStream);
 
-        Vertex currentVertex = null;
-        Edge currentEdge = null;
+		Map<String, String> keyIdMap = new HashMap<String, String>();
+		Map<String, String> keyTypesMaps = new HashMap<String, String>();
+		Map<String, Object> vertexIdMap = new HashMap<String, Object>();
 
-        while (reader.hasNext()) {
+		Vertex currentVertex = null;
+		Edge currentEdge = null;
 
-            Integer eventType = reader.next();
-            if (eventType.equals(XMLEvent.START_ELEMENT)) {
-                String elementName = reader.getName().getLocalPart();
-                if (elementName.equals(GraphMLTokens.KEY)) {
-                    String id = reader.getAttributeValue(null, GraphMLTokens.ID);
-                    String attributeName = reader.getAttributeValue(null, GraphMLTokens.ATTR_NAME);
-                    String attributeType = reader.getAttributeValue(null, GraphMLTokens.ATTR_TYPE);
-                    keyIdMap.put(id, attributeName);
-                    keyTypesMaps.put(attributeName, attributeType);
-                } else if (elementName.equals(GraphMLTokens.NODE)) {
-                    String vertexStringId = reader.getAttributeValue(null, GraphMLTokens.ID);
+		Mode transactionMode = null;
+		boolean isTransactionalGraph = false;
+		Integer transactionBufferSize = 0;
+		if (graph instanceof TransactionalGraph) {
+			transactionMode = ((TransactionalGraph) graph).getTransactionMode();
+			((TransactionalGraph) graph).setTransactionMode(Mode.MANUAL);
+			((TransactionalGraph) graph).startTransaction();
+			isTransactionalGraph = true;
+		}
 
-                    Object vertexObjectId = vertexIdMap.get(vertexStringId);
-                    if (vertexObjectId != null)
-                        currentVertex = graph.getVertex(vertexObjectId);
-                    else {
-                        currentVertex = graph.addVertex(vertexStringId);
-                        vertexIdMap.put(vertexStringId, currentVertex.getId());
-                    }
+		while (reader.hasNext()) {
 
-                } else if (elementName.equals(GraphMLTokens.EDGE)) {
-                    String edgeId = reader.getAttributeValue(null, GraphMLTokens.ID);
-                    String edgeLabel = reader.getAttributeValue(null, GraphMLTokens.LABEL);
-                    edgeLabel = edgeLabel == null ? GraphMLTokens._DEFAULT : edgeLabel;
-                    String outStringId = reader.getAttributeValue(null, GraphMLTokens.SOURCE);
-                    String inStringId = reader.getAttributeValue(null, GraphMLTokens.TARGET);
+			Integer eventType = reader.next();
+			if (eventType.equals(XMLEvent.START_ELEMENT)) {
+				String elementName = reader.getName().getLocalPart();
+				if (elementName.equals(GraphMLTokens.KEY)) {
+					String id = reader
+							.getAttributeValue(null, GraphMLTokens.ID);
+					String attributeName = reader.getAttributeValue(null,
+							GraphMLTokens.ATTR_NAME);
+					String attributeType = reader.getAttributeValue(null,
+							GraphMLTokens.ATTR_TYPE);
+					keyIdMap.put(id, attributeName);
+					keyTypesMaps.put(attributeName, attributeType);
+				} else if (elementName.equals(GraphMLTokens.NODE)) {
+					String vertexStringId = reader.getAttributeValue(null,
+							GraphMLTokens.ID);
 
-                    // TODO: current edge retrieve by id first?
-                    Object outObjectId = vertexIdMap.get(outStringId);
-                    Object inObjectId = vertexIdMap.get(inStringId);
+					Object vertexObjectId = vertexIdMap.get(vertexStringId);
+					if (vertexObjectId != null)
+						currentVertex = graph.getVertex(vertexObjectId);
+					else {
+						currentVertex = graph.addVertex(vertexStringId);
 
-                    Vertex outVertex = null;
-                    if (null != outObjectId)
-                        outVertex = graph.getVertex(outObjectId);
+						transactionBufferSize++;
 
-                    Vertex inVertex = null;
-                    if (null != inObjectId)
-                        inVertex = graph.getVertex(inObjectId);
+						vertexIdMap.put(vertexStringId, currentVertex.getId());
+					}
 
-                    if (null == outVertex) {
-                        outVertex = graph.addVertex(outStringId);
-                        vertexIdMap.put(outStringId, outVertex.getId());
-                    }
-                    if (null == inVertex) {
-                        inVertex = graph.addVertex(inStringId);
-                        vertexIdMap.put(inStringId, inVertex.getId());
-                    }
+				} else if (elementName.equals(GraphMLTokens.EDGE)) {
+					String edgeId = reader.getAttributeValue(null,
+							GraphMLTokens.ID);
+					String edgeLabel = reader.getAttributeValue(null,
+							GraphMLTokens.LABEL);
+					edgeLabel = edgeLabel == null ? GraphMLTokens._DEFAULT
+							: edgeLabel;
+					String outStringId = reader.getAttributeValue(null,
+							GraphMLTokens.SOURCE);
+					String inStringId = reader.getAttributeValue(null,
+							GraphMLTokens.TARGET);
 
-                    currentEdge = graph.addEdge(edgeId, outVertex, inVertex, edgeLabel);
+					// TODO: current edge retrieve by id first?
+					Object outObjectId = vertexIdMap.get(outStringId);
+					Object inObjectId = vertexIdMap.get(inStringId);
 
+					Vertex outVertex = null;
+					if (null != outObjectId)
+						outVertex = graph.getVertex(outObjectId);
 
-                } else if (elementName.equals(GraphMLTokens.DATA)) {
-                    String key = reader.getAttributeValue(null, GraphMLTokens.KEY);
-                    String attributeName = keyIdMap.get(key);
-                    if (attributeName != null) {
-                        String value = reader.getElementText();
-                        if (currentVertex != null) {
-                            currentVertex.setProperty(key, typeCastValue(key, value, keyTypesMaps));
-                        } else if (currentEdge != null) {
-                            currentEdge.setProperty(key, typeCastValue(key, value, keyTypesMaps));
-                        }
-                    }
-                }
-            } else if (eventType.equals(XMLEvent.END_ELEMENT)) {
-                String elementName = reader.getName().getLocalPart();
-                if (elementName.equals(GraphMLTokens.NODE))
-                    currentVertex = null;
-                else if (elementName.equals(GraphMLTokens.EDGE))
-                    currentEdge = null;
+					Vertex inVertex = null;
+					if (null != inObjectId)
+						inVertex = graph.getVertex(inObjectId);
 
-            }
-        }
-        reader.close();
-    }
+					if (null == outVertex) {
+						outVertex = graph.addVertex(outStringId);
 
-    public static Object typeCastValue(String key, String value, Map<String, String> keyTypes) {
-        String type = keyTypes.get(key);
-        if (null == type || type.equals(GraphMLTokens.STRING))
-            return value;
-        else if (type.equals(GraphMLTokens.FLOAT))
-            return Float.valueOf(value);
-        else if (type.equals(GraphMLTokens.INT))
-            return Integer.valueOf(value);
-        else if (type.equals(GraphMLTokens.DOUBLE))
-            return Double.valueOf(value);
-        else if (type.equals(GraphMLTokens.BOOLEAN))
-            return Boolean.valueOf(value);
-        else if (type.equals(GraphMLTokens.LONG))
-            return Long.valueOf(value);
-        else
-            return value;
-    }
+						transactionBufferSize++;
+
+						vertexIdMap.put(outStringId, outVertex.getId());
+					}
+					if (null == inVertex) {
+						inVertex = graph.addVertex(inStringId);
+
+						transactionBufferSize++;
+
+						vertexIdMap.put(inStringId, inVertex.getId());
+					}
+
+					currentEdge = graph.addEdge(edgeId, outVertex, inVertex,
+							edgeLabel);
+
+					transactionBufferSize++;
+
+				} else if (elementName.equals(GraphMLTokens.DATA)) {
+					String key = reader.getAttributeValue(null,
+							GraphMLTokens.KEY);
+					String attributeName = keyIdMap.get(key);
+					if (attributeName != null) {
+						String value = reader.getElementText();
+						if (currentVertex != null) {
+							currentVertex.setProperty(key, typeCastValue(key,
+									value, keyTypesMaps));
+
+							transactionBufferSize++;
+
+						} else if (currentEdge != null) {
+							currentEdge.setProperty(key, typeCastValue(key,
+									value, keyTypesMaps));
+
+							transactionBufferSize++;
+
+						}
+					}
+				}
+			} else if (eventType.equals(XMLEvent.END_ELEMENT)) {
+				String elementName = reader.getName().getLocalPart();
+				if (elementName.equals(GraphMLTokens.NODE))
+					currentVertex = null;
+				else if (elementName.equals(GraphMLTokens.EDGE))
+					currentEdge = null;
+
+			}
+
+			if (isTransactionalGraph
+					&& (transactionBufferSize > GraphMLReader.TRANSACTION_BUFFER)) {
+				((TransactionalGraph) graph)
+						.stopTransaction(Conclusion.SUCCESS);
+				((TransactionalGraph) graph).startTransaction();
+				transactionBufferSize = 0;
+			}
+
+		}
+		reader.close();
+
+		if (isTransactionalGraph) {
+			((TransactionalGraph) graph).stopTransaction(Conclusion.SUCCESS);
+			((TransactionalGraph) graph).setTransactionMode(transactionMode);
+		}
+
+	}
+
+	public static Object typeCastValue(String key, String value,
+			Map<String, String> keyTypes) {
+		String type = keyTypes.get(key);
+		if (null == type || type.equals(GraphMLTokens.STRING))
+			return value;
+		else if (type.equals(GraphMLTokens.FLOAT))
+			return Float.valueOf(value);
+		else if (type.equals(GraphMLTokens.INT))
+			return Integer.valueOf(value);
+		else if (type.equals(GraphMLTokens.DOUBLE))
+			return Double.valueOf(value);
+		else if (type.equals(GraphMLTokens.BOOLEAN))
+			return Boolean.valueOf(value);
+		else if (type.equals(GraphMLTokens.LONG))
+			return Long.valueOf(value);
+		else
+			return value;
+	}
 }


### PR DESCRIPTION
Minor change to GraphMLReader to improve performance.
Before starting, checks if Graph is a TransactionalGraph. 
If it is, Mode is set to Manual and a transaction is committed after every N (1000 at the moment) write operations.
After file load is complete, Mode is reset back to whatever it was set to originally.

Tested quick-n-dirty on my own laptop, on a graph with approx ~1000 vertices ~2000 edges.
I did 3 runs without the changes and 3 runs with the changes. 
With changes it was about 30x faster.
- Without changes (1 operation per transaction?):
  - 133767 ms
  - 129141 ms
  - 132738 ms
- With changes (1000 operations per transaction - in this case, 3 transactions were committed):
  - 3430 ms
  - 4198 ms
  - 3624 ms

PS: Sorry about file format change, my Eclipse auto-format settings are default and obviously different to yours
