### PR TITLE
AutomaticIndex keys saved in config

### DIFF
--- a/src/main/java/com/tinkerpop/blueprints/pgm/impls/orientdb/OrientAutomaticIndex.java
+++ b/src/main/java/com/tinkerpop/blueprints/pgm/impls/orientdb/OrientAutomaticIndex.java
@@ -1,10 +1,10 @@
 package com.tinkerpop.blueprints.pgm.impls.orientdb;
 
-import com.orientechnologies.orient.core.id.ORecordId;
-import com.tinkerpop.blueprints.pgm.AutomaticIndex;
-
 import java.util.HashSet;
 import java.util.Set;
+
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.tinkerpop.blueprints.pgm.AutomaticIndex;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -13,20 +13,14 @@ public class OrientAutomaticIndex<T extends OrientElement> extends OrientIndex<T
 
     Set<String> autoIndexKeys = null;
 
-    public OrientAutomaticIndex(String name, Class<T> indexClass, Set<String> autoIndexKeys, OrientGraph graph) {
-        super(name, indexClass, graph);
-        if (null != autoIndexKeys) {
-            this.autoIndexKeys = new HashSet<String>();
-            this.autoIndexKeys.addAll(autoIndexKeys);
-        }
+    public OrientAutomaticIndex(String name, Class<T> indexClass, Set<String> autoIndexKeys, OrientGraph graph, ODocument indexCfg) {
+        super(name, indexClass, graph, indexCfg);
+        init(autoIndexKeys);
     }
 
-    public OrientAutomaticIndex(String name, Class<T> indexClass, Set<String> autoIndexKeys, OrientGraph graph, ORecordId treeMapRid) {
-        super(name, indexClass, graph, treeMapRid);
-        if (null != autoIndexKeys) {
-            this.autoIndexKeys = new HashSet<String>();
-            this.autoIndexKeys.addAll(autoIndexKeys);
-        }
+    public OrientAutomaticIndex(String name, Set<String> autoIndexKeys, OrientGraph graph, ODocument indexCfg) {
+        super(name, null, graph, indexCfg);
+        init(autoIndexKeys);
     }
 
     public void addAutoIndexKey(String key) {
@@ -40,6 +34,8 @@ public class OrientAutomaticIndex<T extends OrientElement> extends OrientIndex<T
                 this.autoIndexKeys.add(key);
             }
         }
+        
+        saveConfiguration();
     }
 
     protected void autoUpdate(String key, Object newValue, Object oldValue, T element) {
@@ -59,9 +55,24 @@ public class OrientAutomaticIndex<T extends OrientElement> extends OrientIndex<T
     public void removeAutoIndexKey(String key) {
         if (null != this.autoIndexKeys)
             this.autoIndexKeys.remove(key);
+
+        saveConfiguration();
     }
 
     public Set<String> getAutoIndexKeys() {
         return this.autoIndexKeys;
     }
+
+		private void init(Set<String> autoIndexKeys) {
+			if (null != autoIndexKeys) {
+			    this.autoIndexKeys = new HashSet<String>();
+			    this.autoIndexKeys.addAll(autoIndexKeys);
+			}
+      indexCfg.field("keys", autoIndexKeys );
+		}
+
+		private void saveConfiguration() {
+			indexCfg.field("keys", autoIndexKeys );
+			graph.saveIndexConfiguration();
+		}
 }

--- a/src/test/java/com/tinkerpop/blueprints/pgm/impls/orientdb/OrientGraphTest.java
+++ b/src/test/java/com/tinkerpop/blueprints/pgm/impls/orientdb/OrientGraphTest.java
@@ -82,6 +82,9 @@ public class OrientGraphTest extends BaseTest {
         if (doTest == null || doTest.equals("true")) {
             String directory = System.getProperty("orientGraphDirectory");
             if (directory == null) {
+            	if (System.getProperty("os.name").toUpperCase().contains("WINDOWS"))
+            		directory = "C:/temp/blueprints_test";
+            	else
                 directory = "/tmp/blueprints_test";
             }
             deleteDirectory(new File(directory));


### PR DESCRIPTION
Hi,
done.

Just committed the new version with:
- index configuration (as ODocument instance) is always passed in creation
- each index has own config document inside of it
- auto index saves the set called "keys" as configuration
- small refactoring to use always the constants as field names

Tested with Test suite ;-)

bye,
Lvc@
