### PR TITLE
OrientDB updates

### DIFF
--- a/src/test/java/com/tinkerpop/blueprints/pgm/IndexableGraphTestSuite.java
+++ b/src/test/java/com/tinkerpop/blueprints/pgm/IndexableGraphTestSuite.java
@@ -190,7 +190,7 @@ public class IndexableGraphTestSuite extends TestSuite {
         }
     }
 
-    /*public void testIndicesDroppedOnClear() {
+    public void testIndicesDroppedOnClear() {
         IndexableGraph graph = (IndexableGraph) this.graphTest.getGraphInstance();
         int count = 0;
         if (graphTest.supportsVertexIndex)
@@ -225,6 +225,6 @@ public class IndexableGraphTestSuite extends TestSuite {
             graph.shutdown();
 
         }
-    }*/
+    }
 
 }

--- a/src/test/java/com/tinkerpop/blueprints/pgm/impls/orientdb/OrientGraphTest.java
+++ b/src/test/java/com/tinkerpop/blueprints/pgm/impls/orientdb/OrientGraphTest.java
@@ -89,6 +89,7 @@ public class OrientGraphTest extends GraphTest {
                 if (method.getName().startsWith("test")) {
                     System.out.println("Testing " + method.getName() + "...");
                     method.invoke(testSuite);
+                    OrientGraph.delete("local:" + directory + "/graph");
                     deleteDirectory(new File(directory));
                 }
             }


### PR DESCRIPTION
Fixed issue on dropIndex() to save the configuration permanently and in clear() to avoid the re-creation of default automatic indexes. Furthermore I've added the call to db.delete() to be sure that the db is deleted between a test and another. This is due to a behavior in Windows systems: files are not release until the Garbage Collector frees all the resources
