### PR TITLE
attachment of sources and javadoc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,124 +1,135 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-    <groupId>com.tinkerpop.blueprints</groupId>
-    <artifactId>blueprints</artifactId>
-    <version>1.2-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <url>http://blueprints.tinkerpop.com</url>
-    <name>Blueprints: A Property Graph Model Interface</name>
-    <description>Blueprints is a property graph model interface. It provides implementations, ouplementations, test
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+	<groupId>com.tinkerpop.blueprints</groupId>
+	<artifactId>blueprints</artifactId>
+	<version>1.2-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<url>http://blueprints.tinkerpop.com</url>
+	<name>Blueprints: A Property Graph Model Interface</name>
+	<description>Blueprints is a property graph model interface. It provides implementations, ouplementations, test
         suites, and supporting utilities.
     </description>
-    <inceptionYear>2010</inceptionYear>
-    <licenses>
-        <license>
-            <name>BSD 3-Clause</name>
-            <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
-        </license>
-    </licenses>
-    <scm>
-        <connection>scm:git:git@github.com:tinkerpop/blueprints.git</connection>
-        <developerConnection>scm:git:git@github.com:tinkerpop/blueprints.git</developerConnection>
-        <url>git@github.com:tinkerpop/blueprints.git</url>
-    </scm>
-    <contributors>
-        <contributor>
-            <name>Marko A. Rodriguez</name>
-            <email>marko@markorodriguez.com</email>
-            <url>http://markorodriguez.com</url>
-        </contributor>
-        <contributor>
-            <name>Stephen Mallette</name>
-            <email>spmva@genoprime.com</email>
-            <url>http://stephen.genoprime.com</url>
-        </contributor>
-        <contributor>
-            <name>Joshua Shinavier</name>
-            <email>josh@fortytwo.net</email>
-            <url>http://fortytwo.net</url>
-        </contributor>
-        <contributor>
-            <name>Luca Garulli</name>
-            <email>l.garulli@orientechnologies.com</email>
-            <url>http://zion-city.blogspot.com</url>
-        </contributor>
-        <contributor>
-            <name>Darrick Wiebe</name>
-            <email>darrick@innatesoftware.com</email>
-            <url>http://github.com/pangloss</url>
-        </contributor>
-    </contributors>
+	<inceptionYear>2010</inceptionYear>
+	<licenses>
+		<license>
+			<name>BSD 3-Clause</name>
+			<url>http://www.opensource.org/licenses/BSD-3-Clause</url>
+		</license>
+	</licenses>
+	<scm>
+		<connection>scm:git:git@github.com:tinkerpop/blueprints.git</connection>
+		<developerConnection>scm:git:git@github.com:tinkerpop/blueprints.git</developerConnection>
+		<url>git@github.com:tinkerpop/blueprints.git</url>
+	</scm>
+	<contributors>
+		<contributor>
+			<name>Marko A. Rodriguez</name>
+			<email>marko@markorodriguez.com</email>
+			<url>http://markorodriguez.com</url>
+		</contributor>
+		<contributor>
+			<name>Stephen Mallette</name>
+			<email>spmva@genoprime.com</email>
+			<url>http://stephen.genoprime.com</url>
+		</contributor>
+		<contributor>
+			<name>Joshua Shinavier</name>
+			<email>josh@fortytwo.net</email>
+			<url>http://fortytwo.net</url>
+		</contributor>
+		<contributor>
+			<name>Luca Garulli</name>
+			<email>l.garulli@orientechnologies.com</email>
+			<url>http://zion-city.blogspot.com</url>
+		</contributor>
+		<contributor>
+			<name>Darrick Wiebe</name>
+			<email>darrick@innatesoftware.com</email>
+			<url>http://github.com/pangloss</url>
+		</contributor>
+	</contributors>
 
-    <modules>
-        <module>blueprints-core</module>
-        <module>blueprints-dex-graph</module>
-        <module>blueprints-graph-jung</module>
-        <module>blueprints-graph-sail</module>
-        <module>blueprints-neo4j-graph</module>
-        <module>blueprints-neo4jbatch-graph</module>
-        <module>blueprints-orient-graph</module>
-        <module>blueprints-rexster-graph</module>
-        <module>blueprints-sail-graph</module>
-        <module>blueprints-test</module>
-    </modules>
+	<modules>
+		<module>blueprints-core</module>
+		<module>blueprints-dex-graph</module>
+		<module>blueprints-graph-jung</module>
+		<module>blueprints-graph-sail</module>
+		<module>blueprints-neo4j-graph</module>
+		<module>blueprints-neo4jbatch-graph</module>
+		<module>blueprints-orient-graph</module>
+		<module>blueprints-rexster-graph</module>
+		<module>blueprints-sail-graph</module>
+		<module>blueprints-test</module>
+	</modules>
 
-    <properties>
-        <blueprints.version>1.2-SNAPSHOT</blueprints.version>
-        <sesame.version>2.6.0</sesame.version>
-        <sesametools.version>1.6</sesametools.version>
-        <junit.version>4.5</junit.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    </properties>
+	<properties>
+		<blueprints.version>1.2-SNAPSHOT</blueprints.version>
+		<sesame.version>2.6.0</sesame.version>
+		<sesametools.version>1.6</sesametools.version>
+		<junit.version>4.5</junit.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
 
-    <build>
-        <directory>${basedir}/target</directory>
-        <plugins>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.5</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.wagon</groupId>
-                        <artifactId>wagon-ftp</artifactId>
-                        <version>1.0-alpha-6</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<directory>${basedir}/target</directory>
+		<plugins>
+			<plugin>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.5</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.wagon</groupId>
+						<artifactId>wagon-ftp</artifactId>
+						<version>1.0-alpha-6</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <aggregate>true</aggregate>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<aggregate>true</aggregate>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>


### PR DESCRIPTION
As suggested by Marko in Tinkerpop ML (http://groups.google.com/group/gremlin-users/msg/779d39b65bcf7fa5), I took the freedom to update POM in order to attach sources to artifacts.
It should work on all blueprints submodules, and should also be easy to add to other Tinkerpop projects.
