### PR TITLE
Small optimization in TinkerGraph.removeVertex

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/impls/tg/TinkerGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/impls/tg/TinkerGraph.java
@@ -176,14 +176,10 @@ public class TinkerGraph implements IndexableGraph, Serializable {
     }
 
     public void removeVertex(final Vertex vertex) {
-        Set<Edge> toRemove = new HashSet<Edge>();
         for (Edge edge : vertex.getInEdges()) {
-            toRemove.add(edge);
+            this.removeEdge(edge);
         }
         for (Edge edge : vertex.getOutEdges()) {
-            toRemove.add(edge);
-        }
-        for (Edge edge : toRemove) {
             this.removeEdge(edge);
         }
 


### PR DESCRIPTION
Don't build up a HashSet of edges to remove, it's a waste of memory.
Instead, just delete the edges as they're found.
