### PR TITLE
Pull out the common getRawGraph method from all of the graphs in the wrappers package and put it into a new GraphWrapper interface.

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/GraphWrapper.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/GraphWrapper.java
@@ -1,0 +1,17 @@
+package com.tinkerpop.blueprints.pgm.util.wrappers;
+
+import com.tinkerpop.blueprints.pgm.Graph;
+
+/**
+ * A GraphWrapper is a Blueprints Graph that has an underlying Graph object to which it delegates
+ * its operations.
+ *
+ * @author Jordan A. Lewis (http://jordanlewis.org)
+ */
+public interface GraphWrapper extends Graph {
+    /**
+     * Get the graph this wrapper delegates to.
+     * @return the underlying Blueprints graph that this GraphWrapper delegates its operations to.
+     */
+    public Graph getRawGraph();
+}

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/event/EventGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/event/EventGraph.java
@@ -4,6 +4,7 @@ import com.tinkerpop.blueprints.pgm.Edge;
 import com.tinkerpop.blueprints.pgm.Graph;
 import com.tinkerpop.blueprints.pgm.Vertex;
 import com.tinkerpop.blueprints.pgm.impls.StringFactory;
+import com.tinkerpop.blueprints.pgm.util.wrappers.GraphWrapper;
 import com.tinkerpop.blueprints.pgm.util.wrappers.event.listener.GraphChangedListener;
 import com.tinkerpop.blueprints.pgm.util.wrappers.event.util.EventEdgeSequence;
 import com.tinkerpop.blueprints.pgm.util.wrappers.event.util.EventVertexSequence;
@@ -26,7 +27,7 @@ import java.util.List;
  *
  * @author Stephen Mallette
  */
-public class EventGraph implements Graph {
+public class EventGraph implements GraphWrapper {
     protected final Graph rawGraph;
 
     protected final List<GraphChangedListener> graphChangedListeners = new ArrayList<GraphChangedListener>();
@@ -182,6 +183,7 @@ public class EventGraph implements Graph {
         return StringFactory.graphString(this, this.rawGraph.toString());
     }
 
+    @Override
     public Graph getRawGraph() {
         return this.rawGraph;
     }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/partition/PartitionGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/partition/PartitionGraph.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.pgm.Element;
 import com.tinkerpop.blueprints.pgm.Graph;
 import com.tinkerpop.blueprints.pgm.Vertex;
 import com.tinkerpop.blueprints.pgm.impls.StringFactory;
+import com.tinkerpop.blueprints.pgm.util.wrappers.GraphWrapper;
 import com.tinkerpop.blueprints.pgm.util.wrappers.partition.util.PartitionEdgeSequence;
 import com.tinkerpop.blueprints.pgm.util.wrappers.partition.util.PartitionVertexSequence;
 
@@ -15,7 +16,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class PartitionGraph implements Graph {
+public class PartitionGraph implements GraphWrapper {
 
     protected Graph rawGraph;
     private String writePartition;
@@ -126,6 +127,7 @@ public class PartitionGraph implements Graph {
         this.rawGraph.removeVertex(((PartitionVertex) vertex).getRawVertex());
     }
 
+    @Override
     public Graph getRawGraph() {
         return this.rawGraph;
     }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/readonly/ReadOnlyGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/readonly/ReadOnlyGraph.java
@@ -4,6 +4,7 @@ import com.tinkerpop.blueprints.pgm.Edge;
 import com.tinkerpop.blueprints.pgm.Graph;
 import com.tinkerpop.blueprints.pgm.Vertex;
 import com.tinkerpop.blueprints.pgm.impls.StringFactory;
+import com.tinkerpop.blueprints.pgm.util.wrappers.GraphWrapper;
 import com.tinkerpop.blueprints.pgm.util.wrappers.readonly.util.ReadOnlyEdgeSequence;
 import com.tinkerpop.blueprints.pgm.util.wrappers.readonly.util.ReadOnlyVertexSequence;
 
@@ -13,7 +14,7 @@ import com.tinkerpop.blueprints.pgm.util.wrappers.readonly.util.ReadOnlyVertexSe
  *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class ReadOnlyGraph implements Graph {
+public class ReadOnlyGraph implements GraphWrapper {
 
     protected final Graph rawGraph;
 
@@ -91,6 +92,7 @@ public class ReadOnlyGraph implements Graph {
         return StringFactory.graphString(this, this.rawGraph.toString());
     }
 
+    @Override
     public Graph getRawGraph() {
         return this.rawGraph;
     }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/wrapped/WrappedGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/pgm/util/wrappers/wrapped/WrappedGraph.java
@@ -4,13 +4,14 @@ import com.tinkerpop.blueprints.pgm.Edge;
 import com.tinkerpop.blueprints.pgm.Graph;
 import com.tinkerpop.blueprints.pgm.Vertex;
 import com.tinkerpop.blueprints.pgm.impls.StringFactory;
+import com.tinkerpop.blueprints.pgm.util.wrappers.GraphWrapper;
 import com.tinkerpop.blueprints.pgm.util.wrappers.wrapped.util.WrappedEdgeSequence;
 import com.tinkerpop.blueprints.pgm.util.wrappers.wrapped.util.WrappedVertexSequence;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class WrappedGraph implements Graph {
+public class WrappedGraph implements GraphWrapper {
 
     protected Graph rawGraph;
 
@@ -66,6 +67,7 @@ public class WrappedGraph implements Graph {
         this.rawGraph.removeVertex(((WrappedVertex) vertex).getRawVertex());
     }
 
+    @Override
     public Graph getRawGraph() {
         return this.rawGraph;
     }


### PR DESCRIPTION
The GraphWrapper interface extends Graph with a getRawGraph() method,
which all graph implementations in the wrappers/ package currently
implement.

This provides a reasonable abstraction. It also enables completing and
cleaning up the RexsterApplicationGraph.unwrapGraph method, which
currently only works for ReadOnlyGraphs and EventGraphs anyway.
