### PR TITLE
Blueprints-DexGraph goes to dexjava 4.5.1

### DIFF
--- a/blueprints-dex-graph/pom.xml
+++ b/blueprints-dex-graph/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.sparsity</groupId>
             <artifactId>dexjava</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>


### PR DESCRIPTION
I have updated the Dex driver for blueprints to the latest version of dexjava (4.5.1).
At this moment and as required, all tests work successfully.
Let me know if you have some question.
