### PR TITLE
OrientDB iterators are allowed to pass end

### DIFF
--- a/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/pgm/impls/orientdb/util/OrientElementSequence.java
+++ b/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/pgm/impls/orientdb/util/OrientElementSequence.java
@@ -31,6 +31,10 @@ public class OrientElementSequence<T extends Element> implements CloseableSequen
     @SuppressWarnings("unchecked")
     public T next() {
         OrientElement currentElement = null;
+        
+        if (!hasNext())
+            throw new NoSuchElementException();
+
         Object current = this.rawIterator.next();
 
         if (null == current)


### PR DESCRIPTION
Hi all, I have a blueprints / frames application that for orientdb allows the iterator to keep being iterated until it is fully consumed.

Further iterations on the iterator raise null pointer exception. Checking if the iterator is still valid prevents this.
