### PR TITLE
OrientDB fix for create key index

### DIFF
--- a/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
+++ b/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
@@ -12,6 +12,7 @@ import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.index.OIndex;
 import com.orientechnologies.orient.core.index.OPropertyIndexDefinition;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OProperty;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.tinkerpop.blueprints.Direction;
@@ -434,8 +435,15 @@ public abstract class OrientBaseGraph implements IndexableGraph, MetaGraph<OGrap
         final String className = getClassName(elementClass);
         final OClass cls = getRawGraph().getMetadata().getSchema().getClass(className);
 
+        final OType indexType;
+        final OProperty property = cls.getProperty(key);
+        if (property == null)
+            indexType = OType.STRING;
+        else
+            indexType = property.getType();
+
         getRawGraph().getMetadata().getIndexManager()
-                .createIndex(className + "." + key, "NOTUNIQUE", new OPropertyIndexDefinition(className, key, OType.STRING), cls.getPolymorphicClusterIds(), null);
+                .createIndex(className + "." + key, OClass.INDEX_TYPE.NOTUNIQUE.name(), new OPropertyIndexDefinition(className, key, indexType), cls.getPolymorphicClusterIds(), null);
     }
 
     public <T extends Element> Set<String> getIndexedKeys(final Class<T> elementClass) {


### PR DESCRIPTION
Hi!

This is some fixes of blueprints for OrientDB.
1. OrientBaseGraph:438 it is better to use polymorphic cluster ids, because in other way it may not work perfectly with class hierarchy.
2. OrientBaseGraph:438 when such field already exists in schema it is better to use its type instead of STRING.

Best regards,
Artem Orobets
