### PR TITLE
Support for sub-types in vertexes and edges

### DIFF
--- a/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
+++ b/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
@@ -153,9 +153,15 @@ public abstract class OrientBaseGraph implements IndexableGraph, MetaGraph<OGrap
     }
 
     public Edge addEdge(final Object id, final Vertex outVertex, final Vertex inVertex, final String label) {
+        String className = null; 
+        if( id != null && id instanceof String && id.toString().startsWith(CLASS_PREFIX))
+          // GET THE CLASS NAME
+          className = id.toString().substring( CLASS_PREFIX.length() );
+
+      
         final OGraphDatabase db = getRawGraph();
         this.autoStartTransaction();
-        final ODocument edgeDoc = db.createEdge(((OrientVertex) outVertex).getRawElement(), ((OrientVertex) inVertex).getRawElement());
+        final ODocument edgeDoc = db.createEdge(((OrientVertex) outVertex).getRawElement(), ((OrientVertex) inVertex).getRawElement(), className);
         final OrientEdge edge = new OrientEdge(this, edgeDoc, label);
 
         // SAVE THE VERTICES TO ASSURE THEY ARE IN TX


### PR DESCRIPTION
While OrientDB supports sub-types, Blueprints hasn't this concept. To let the developers to use BP on top of a typed graph database created with OrientDB they need a way to tell to the underlying graph impl the class to use. In this case the only way in my mind (without breaking the API) was to use the non-used id as first parameter in addVertex() and addEdge() methods. If a "class<x>" is passed, where x is the class name, then it's used.
