### PR TITLE
bypass BatchGraph cache for repeated out vertices when using presorted input data

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/BatchGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/BatchGraph.java
@@ -298,6 +298,16 @@ public class BatchGraph<T extends TransactionalGraph> implements TransactionalGr
         return v;
     }
 
+
+
+    /**
+     *
+     * If the input data are sorted, then out vertex will be repeated for several edges in a row.
+     * In this case, bypass cache and instead immediately return a new vertex using the known id.
+     * This gives a modest performance boost, especially when the cache is large or there are 
+     * on average many edges per vertex.
+     * 
+     */
     @Override
     public Vertex getVertex(final Object id) {
         
@@ -347,11 +357,10 @@ public class BatchGraph<T extends TransactionalGraph> implements TransactionalGr
             throw new IllegalArgumentException("Given element was not created in this baseGraph");
         nextElement();
         
-        final Vertex iv = getCachedVertex(inVertex.getId());
         final Vertex ov = getCachedVertex(outVertex.getId());
+        final Vertex iv = getCachedVertex(inVertex.getId());
 
-
-        previousOutVertexId = outVertex.getId();
+        previousOutVertexId = outVertex.getId();  //keep track of the previous out vertex id
 
         currentEdgeCached = baseGraph.addEdge(id, ov, iv, label);
         if (edgeIdKey != null && id != null) {


### PR DESCRIPTION
Edge Input data are often presorted or can easily be sorted before batch loading using BatchGraph.  The current cache implementation in BatchGraph significantly speeds up loading presorted data, but for large cache sizes (or if the cache is turned off), a further performance gain can be had by bypassing the cache when loading a series of edges that have the same outgoing vertices.  The cache is bypassed for only the outgoing vertex lookup, and only after it is a repeat of the previous outgoing vertex in the previous edge added.

I've added a few lines of code to BatchGraph that implement this.  In a simple test loading of 20 million presorted edges (with an average of 10 edges per vertex), this gave an overall performance boost of 3%, with most of the gains coming from the end of the loading process.  The performance gain for the last million edges loaded was over 5%; it should give even more of a boost when loading much bigger data sets, or sets that have high numbers of edges per vertex.  I observed no performance penalty when loading data that are not presorted.
