### PR TITLE
Add ReadOnlyKeyIndexableGraphWrapper

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/readonly/ReadOnlyKeyIndexableGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/readonly/ReadOnlyKeyIndexableGraph.java
@@ -1,0 +1,37 @@
+package com.tinkerpop.blueprints.util.wrappers.readonly;
+
+import java.util.Set;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.IndexableGraph;
+import com.tinkerpop.blueprints.KeyIndexableGraph;
+import com.tinkerpop.blueprints.util.wrappers.WrapperGraph;
+
+/**
+ * A ReadOnlyKeyIndexableGraph wraps a KeyIndexableGraph and overrides the underlying graph's mutating methods.
+ * In this way, a ReadOnlyKeyIndexableGraph can only be read from, not written to.
+ *
+ * @author Darrick Wiebe (http://૯.com/)
+ */
+public class ReadOnlyKeyIndexableGraph<T extends KeyIndexableGraph> extends ReadOnlyIndexableGraph<IndexableGraph> implements KeyIndexableGraph {
+    public ReadOnlyKeyIndexableGraph(final T baseKIGraph) {
+        super((IndexableGraph)baseKIGraph);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public <T extends Element> void dropKeyIndex(final String name, Class<T> elementClass) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException(ReadOnlyTokens.MUTATE_ERROR_MESSAGE);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public <T extends Element> void createKeyIndex(final String name, Class<T> elementClass) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException(ReadOnlyTokens.MUTATE_ERROR_MESSAGE);
+    }
+
+    public <T extends Element> Set<String> getIndexedKeys(Class<T> elementClass) {
+        return ((KeyIndexableGraph)this.baseGraph).getIndexedKeys(elementClass);
+    }
+}

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/wrappers/readonly/ReadOnlyGraphTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/wrappers/readonly/ReadOnlyGraphTest.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Index;
+import com.tinkerpop.blueprints.KeyIndexableGraph;
 import com.tinkerpop.blueprints.IndexableGraph;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
@@ -122,5 +123,25 @@ public class ReadOnlyGraphTest extends BaseTest {
         }
         assertTrue(Vertex.class.isAssignableFrom(index.getIndexClass()));
         assertEquals(index.getIndexName(), "blah");
+    }
+
+    public void testReadOnlyKeyIndices() {
+        KeyIndexableGraph graph = new ReadOnlyKeyIndexableGraph<TinkerGraph>(TinkerGraphFactory.createTinkerGraph());
+        ((KeyIndexableGraph)((WrapperGraph<IndexableGraph>) graph).getBaseGraph()).createKeyIndex("blah", Vertex.class);
+        assertTrue(graph.getIndexedKeys(Vertex.class) instanceof Set);
+        assertEquals(graph.getIndexedKeys(Vertex.class).size(), 1);
+        assertTrue(graph.getIndexedKeys(Vertex.class).contains("blah"));
+        try {
+            graph.createKeyIndex("whatever", Vertex.class);
+            assertTrue(false);
+        } catch (UnsupportedOperationException e) {
+            assertTrue(true);
+        }
+        try {
+            graph.dropKeyIndex("blah", Vertex.class);
+            assertTrue(false);
+        } catch (UnsupportedOperationException e) {
+            assertTrue(true);
+        }
     }
 }


### PR DESCRIPTION
The `getIndexedKeys` method is frequently useful; hence this wrapper.
