### PR TITLE
Replaced the usage of a deprecated

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/ThreadedTransactionalGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/ThreadedTransactionalGraph.java
@@ -5,7 +5,7 @@ package com.tinkerpop.blueprints;
  * While TransactionalGraph binds each transaction to the executing thread, ThreadedTransactionalGraph's {@link #startTransaction} returns a {@link TransactionalGraph} that represents its own transactional context independent of the executing thread.
  * Hence, one can have multiple threads operating against a single transaction represented by the returned TransactionalGraph object. This is useful for parallelizing graph algorithms.
  * <p/>
- * Note, that one needs to call {@link TransactionalGraph#stopTransaction(com.tinkerpop.blueprints.TransactionalGraph.Conclusion)} to close the transactions returned
+ * Note, that one needs to call {@link TransactionalGraph#commit()} or {@link TransactionalGraph#rollback()} to close the transactions returned
  * by {@link #startTransaction()}.
  *
  * @author Matthias Brocheler (http://matthiasb.com)

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/KeyIndexableGraphHelper.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/KeyIndexableGraphHelper.java
@@ -33,7 +33,7 @@ public class KeyIndexableGraphHelper {
                     element.setProperty(key, value);
 
                     if (isTransactional && (counter % 1000 == 0)) {
-                        ((TransactionalGraph) graph).stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+                        ((TransactionalGraph) graph).commit();;
                     }
                 }
             }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/gml/GMLReader.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/gml/GMLReader.java
@@ -151,7 +151,7 @@ public class GMLReader {
 
             new GMLParser(graph, defaultEdgeLabel, vertexIdKey, edgeIdKey, edgeLabelKey).parse(st);
 
-            graph.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+            graph.commit();;
         } catch (IOException e) {
             throw new IOException("GML malformed line number " + st.lineno() + ": ", e);
         }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphml/GraphMLReader.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphml/GraphMLReader.java
@@ -243,7 +243,7 @@ public class GraphMLReader {
 
             reader.close();
 
-            graph.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+            graph.commit();;
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONReader.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONReader.java
@@ -115,7 +115,7 @@ public class GraphSONReader {
 
         jp.close();
 
-        graph.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+        graph.commit();;
     }
 
 

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/BatchGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/BatchGraph.java
@@ -235,7 +235,7 @@ public class BatchGraph<T extends TransactionalGraph> implements TransactionalGr
         currentEdge = null;
         currentEdgeCached = null;
         if (remainingBufferSize <= 0) {
-            baseGraph.stopTransaction(Conclusion.SUCCESS);
+            baseGraph.commit();
             cache.newTransaction();
             remainingBufferSize = bufferSize;
         }
@@ -254,7 +254,7 @@ public class BatchGraph<T extends TransactionalGraph> implements TransactionalGr
         currentEdge = null;
         currentEdgeCached = null;
         remainingBufferSize = 0;
-        baseGraph.stopTransaction(Conclusion.SUCCESS);
+        baseGraph.commit();
     }
 
     public void commit() {
@@ -270,7 +270,7 @@ public class BatchGraph<T extends TransactionalGraph> implements TransactionalGr
 
     @Override
     public void shutdown() {
-        baseGraph.stopTransaction(Conclusion.SUCCESS);
+        baseGraph.commit();
         baseGraph.shutdown();
         currentEdge = null;
         currentEdgeCached = null;

--- a/blueprints-dex-graph/src/main/java/com/tinkerpop/blueprints/impls/dex/DexGraph.java
+++ b/blueprints-dex-graph/src/main/java/com/tinkerpop/blueprints/impls/dex/DexGraph.java
@@ -601,7 +601,7 @@ public class DexGraph implements MetaGraph<com.sparsity.dex.gdb.Graph>, KeyIndex
       */
     @Override
     public void shutdown() {
-        stopTransaction(Conclusion.SUCCESS);
+        commit();
         
         db.close();
         dex.close();

--- a/blueprints-dex-graph/src/test/java/com/tinkerpop/blueprints/impls/dex/DexSpecificTestSuite.java
+++ b/blueprints-dex-graph/src/test/java/com/tinkerpop/blueprints/impls/dex/DexSpecificTestSuite.java
@@ -115,19 +115,19 @@ public class DexSpecificTestSuite extends TestSuite {
         TransactionalGraph graph = (TransactionalGraph) graphTest.generateGraph();
         this.stopWatch();
 
-        graph.stopTransaction(Conclusion.SUCCESS);
+        graph.commit();
 
         graph.addVertex(null).setProperty("name", "sergio");
         graph.addVertex(null).setProperty("name", "marko");
         assertTrue(graph.getVertices("name", "sergio").iterator().next()
                 .getProperty("name").equals("sergio"));
-        graph.stopTransaction(Conclusion.SUCCESS);
+        graph.commit();
         assertTrue(((DexGraph) graph).getRawSession(false) == null);
 
         assertTrue(graph.getVertices("name", "sergio").iterator().next().getProperty("name").equals("sergio"));
-        graph.stopTransaction(Conclusion.SUCCESS);
+        graph.commit();
         assertTrue(((DexGraph) graph).getRawSession(false) == null);
-        graph.stopTransaction(Conclusion.SUCCESS);
+        graph.commit();
         assertTrue(((DexGraph) graph).getRawSession(false) == null);
 
         graph.addVertex(null);
@@ -156,7 +156,7 @@ public class DexSpecificTestSuite extends TestSuite {
                     }
                 }
             }
-            tg.stopTransaction(Conclusion.SUCCESS);
+            tg.commit();
             finished = true;
         }
     }

--- a/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSail.java
+++ b/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSail.java
@@ -142,7 +142,7 @@ public class GraphSail<T extends KeyIndexableGraph> extends NotifyingSailBase im
                 store.namespaces = store.addVertex(NAMESPACES_VERTEX_ID);
             } finally {
                 if (store.manualTransactions) {
-                    ((TransactionalGraph) graph).stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+                    ((TransactionalGraph) graph).commit();;
                 }
             }
         }

--- a/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSailConnection.java
+++ b/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSailConnection.java
@@ -55,7 +55,7 @@ public class GraphSailConnection extends NotifyingSailConnectionBase implements 
 
     public void commitInternal() throws SailException {
         if (store.manualTransactions) {
-            ((TransactionalGraph) store.graph).stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+            ((TransactionalGraph) store.graph).commit();;
         }
 
         if (statementsAdded || statementsRemoved) {

--- a/blueprints-neo4j-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraph.java
+++ b/blueprints-neo4j-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraph.java
@@ -167,9 +167,9 @@ public class Neo4jGraph implements TransactionalGraph, IndexableGraph, KeyIndexa
         try {
             this.autoStartTransaction();
             this.removeVertex(this.getVertex(0));
-            this.stopTransaction(Conclusion.SUCCESS);
+            this.commit();
         } catch (Exception e) {
-            this.stopTransaction(Conclusion.FAILURE);
+            this.rollback();
         }
     }
 
@@ -263,7 +263,7 @@ public class Neo4jGraph implements TransactionalGraph, IndexableGraph, KeyIndexa
                 relationshipIndex.delete();
             }
         }
-        this.stopTransaction(Conclusion.SUCCESS);
+        this.commit();
     }
 
 
@@ -487,7 +487,7 @@ public class Neo4jGraph implements TransactionalGraph, IndexableGraph, KeyIndexa
 
     public void shutdown() {
         try {
-            this.stopTransaction(Conclusion.SUCCESS);
+            this.commit();
         } catch (TransactionFailureException e) {
             //TODO: inspect why certain transactions fail
         }

--- a/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
+++ b/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
@@ -323,7 +323,7 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
      */
     public void loadRDF(final InputStream input, final String baseURI, final String format, final String baseGraph) {
         try {
-            this.stopTransaction(Conclusion.SUCCESS);
+            this.commit();
             final SailConnection c = this.rawGraph.getConnection();
             try {
                 RDFParser p = Rio.createParser(getFormat(format));
@@ -375,7 +375,7 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
 
     public synchronized void shutdown() {
         try {
-            this.stopTransaction(Conclusion.SUCCESS);
+            this.commit();
             closeAllConnections();
             this.rawGraph.shutDown();
         } catch (Throwable e) {

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/wrappers/batch/BatchGraphTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/wrappers/batch/BatchGraphTest.java
@@ -193,7 +193,7 @@ public class BatchGraphTest extends TestCase {
             previous = next;
         }
 
-        loader.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+        loader.commit();;
         assertTrue(tgraph.allSuccessful());
 
         loader.shutdown();
@@ -279,11 +279,11 @@ public class BatchGraphTest extends TestCase {
         }
 
         public void rollback() {
-            this.stopTransaction(Conclusion.FAILURE);
+            this.rollback();
         }
 
         public void commit() {
-            this.stopTransaction(Conclusion.SUCCESS);
+            this.commit();
         }
 
         @Override


### PR DESCRIPTION
TransactionalGraph.stopTransaction(Conclusion conclusion);

To the appropriate method (commit() / rollback()).
