### PR TITLE
Changed EventTrigger class visibility to public,

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/EventTrigger.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/EventTrigger.java
@@ -5,7 +5,7 @@ import com.tinkerpop.blueprints.util.wrappers.event.listener.Event;
 import java.util.ArrayList;
 import java.util.List;
 
-class EventTrigger {
+public class EventTrigger {
 
     /**
      * A queue of events that are triggered by change to the graph.  The queue builds


### PR DESCRIPTION
This is required when extending EventGraph is neccessary as
EventTrigger instance is required as apart of the EventGraph constructor.
