### PR TITLE
Remove the final keyword from GraphSONUtility.

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONUtility.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONUtility.java
@@ -33,7 +33,7 @@ import static com.tinkerpop.blueprints.util.io.graphson.ElementPropertyConfig.El
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public final class GraphSONUtility {
+public class GraphSONUtility {
 
     private static final JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
     private static final JsonFactory jsonFactory = new MappingJsonFactory();


### PR DESCRIPTION
When parsing GraphSON stream, it may be required to extends
the functionality of the GraphSONUtility class and provide more specific implementation
for special cases.
