### PR TITLE
Compatibility with Java 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.5.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.5</source>
+                        <target>1.5</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
It can sound a stupid idea in 2013, but blueprints should be compiled for Java 5. It's a non-event because :
- source code does not use Java 6 specific features
- releases can still be built with JDK 6

Thanks
