### PR TITLE
OrientElement class scope public

### DIFF
--- a/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElement.java
+++ b/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElement.java
@@ -20,7 +20,7 @@ import java.util.Set;
 /**
  * @author Luca Garulli (http://www.orientechnologies.com)
  */
-abstract class OrientElement implements Element, OSerializableStream, OIdentifiable {
+public abstract class OrientElement implements Element, OSerializableStream, OIdentifiable {
 
     protected final OrientBaseGraph graph;
     protected final ODocument rawElement;


### PR DESCRIPTION
This is required in order to make it easier to extend some blueprints interfaces. Notably com.tinkerpop.blueprints.Index. The parameterized type <T extends Element> necessitates that OrientElement be public.
