### PR TITLE
Organize neo4j artifacts versions

### DIFF
--- a/blueprints-neo4j-graph/pom.xml
+++ b/blueprints-neo4j-graph/pom.xml
@@ -20,20 +20,15 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j</artifactId>
-            <version>1.9.M03</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ha</artifactId>
-            <version>1.9.M03</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-management</artifactId>
-            <version>1.9.M03</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/blueprints-neo4jbatch-graph/pom.xml
+++ b/blueprints-neo4jbatch-graph/pom.xml
@@ -17,12 +17,6 @@
             <artifactId>blueprints-core</artifactId>
             <version>${blueprints.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.neo4j</groupId>
-            <artifactId>neo4j</artifactId>
-            <version>1.9.M03</version>
-            <type>pom</type>
-        </dependency>
         <!-- TESTING -->
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,32 @@
         <junit.version>4.5</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <neo4j.version>1.9.M03</neo4j.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j</artifactId>
+                <version>${neo4j.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-ha</artifactId>
+                <version>${neo4j.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-management</artifactId>
+                <version>${neo4j.version}</version>
+                <scope>compile</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <directory>${basedir}/target</directory>
         <plugins>


### PR DESCRIPTION
Avoid repeating versions in child poms dependencies by inheriting dependencies
from parent POM dependencies management.
