### PR TITLE
Check if tx has begun and db open before to stop tx

### DIFF
--- a/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraph.java
+++ b/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraph.java
@@ -70,6 +70,10 @@ public class OrientGraph extends OrientBaseGraph implements TransactionalGraph {
 
     @Override
     public void stopTransaction(Conclusion conclusion) {
+      final OrientGraphContext context = getContext(false);
+        if (context.rawGraph.isClosed() || context.rawGraph.getTransaction() instanceof OTransactionNoTx || context.rawGraph.getTransaction().getStatus() != TXSTATUS.BEGUN)
+            return;
+      
         if (Conclusion.SUCCESS == conclusion)
             commit();
         else


### PR DESCRIPTION
This fixes:

2013-03-08 09:10:37,029 WARN  sail.GraphSailConnection - Rolling back transaction due to connection close
java.lang.Throwable
    at org.openrdf.sail.helpers.SailConnectionBase.close(SailConnectionBase.java:161)
    at com.tinkerpop.blueprints.impls.sail.SailGraph.loadRDF(SailGraph.java:369)
    at TripleLoadTest.main(TripleLoadTest.java:43)
Exception in thread "main" java.lang.RuntimeException: Database is closed
    at com.tinkerpop.blueprints.impls.sail.SailGraph.shutdown(SailGraph.java:414)
    at TripleLoadTest.main(TripleLoadTest.java:57)
Caused by: java.lang.IllegalStateException: Database is closed
    at com.tinkerpop.blueprints.impls.orient.OrientBaseGraph.openOrCreate(OrientBaseGraph.java:371)
    at com.tinkerpop.blueprints.impls.orient.OrientBaseGraph.getContext(OrientBaseGraph.java:364)
    at com.tinkerpop.blueprints.impls.orient.OrientBaseGraph.getRawGraph(OrientBaseGraph.java:347)
    at com.tinkerpop.blueprints.impls.orient.OrientGraph.stopTransaction(OrientGraph.java:74)
    at com.tinkerpop.blueprints.oupls.sail.GraphSailConnection.closeInternal(GraphSailConnection.java:78)
    at org.openrdf.sail.helpers.SailConnectionBase.close(SailConnectionBase.java:172)
    at com.tinkerpop.blueprints.impls.sail.SailGraph.closeAllConnections(SailGraph.java:402)
    at com.tinkerpop.blueprints.impls.sail.SailGraph.shutdown(SailGraph.java:411)
    ... 1 more
