### PR TITLE
Tinkergraph: Remove Vertex's label Set after last edge removal.

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/impls/tg/TinkerGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/impls/tg/TinkerGraph.java
@@ -321,11 +321,19 @@ public class TinkerGraph implements IndexableGraph, KeyIndexableGraph, Serializa
             final Set<Edge> edges = outVertex.outEdges.get(edge.getLabel());
             if (null != edges)
                 edges.remove(edge);
+
+            if (outVertex.outEdges.get((edge.getLabel())).size() == 0) {
+                outVertex.outEdges.remove(edge.getLabel());
+            }
         }
         if (null != inVertex && null != inVertex.inEdges) {
             final Set<Edge> edges = inVertex.inEdges.get(edge.getLabel());
             if (null != edges)
                 edges.remove(edge);
+
+            if (inVertex.inEdges.get((edge.getLabel())).size() == 0) {
+                inVertex.inEdges.remove(edge.getLabel());
+            }
         }
 
 


### PR DESCRIPTION
Hey,
Please take a look at this patch, I'm not sure whether this is the right approach,
But if the last edge associated with a vertex is deleted, the Set-per-label of associated edges continue to exit and show false results.

Thanks.
