### PR TITLE
EventGraph: Expose removed element properties as a map as a part of the event data.

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/EventGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/EventGraph.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.Features;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.GraphQuery;
 import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.ElementHelper;
 import com.tinkerpop.blueprints.util.StringFactory;
 import com.tinkerpop.blueprints.util.wrappers.WrappedGraphQuery;
 import com.tinkerpop.blueprints.util.wrappers.WrapperGraph;
@@ -17,6 +18,7 @@ import com.tinkerpop.blueprints.util.wrappers.event.listener.VertexRemovedEvent;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An EventGraph is a wrapper to existing Graph implementations and provides for graph events to be raised
@@ -74,8 +76,8 @@ public class EventGraph<T extends Graph> implements Graph, WrapperGraph<T> {
         this.trigger.addEvent(new VertexAddedEvent(vertex));
     }
 
-    protected void onVertexRemoved(final Vertex vertex) {
-        this.trigger.addEvent(new VertexRemovedEvent(vertex));
+    protected void onVertexRemoved(final Vertex vertex, Map<String, Object> props) {
+        this.trigger.addEvent(new VertexRemovedEvent(vertex, props));
     }
 
     protected void onEdgeAdded(Edge edge) {
@@ -117,8 +119,9 @@ public class EventGraph<T extends Graph> implements Graph, WrapperGraph<T> {
             vertexToRemove = ((EventVertex) vertex).getBaseVertex();
         }
 
+        Map<String, Object> props = ElementHelper.getProperties(vertex);
         this.baseGraph.removeVertex(vertexToRemove);
-        this.onVertexRemoved(vertex);
+        this.onVertexRemoved(vertex, props);
     }
 
     public Iterable<Vertex> getVertices() {

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/ConsoleGraphChangedListener.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/ConsoleGraphChangedListener.java
@@ -4,6 +4,8 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 
+import java.util.Map;
+
 /**
  * An example listener that writes a message to the console for each event that fires from the graph.
  *
@@ -29,7 +31,7 @@ public class ConsoleGraphChangedListener implements GraphChangedListener {
         System.out.println("Vertex [" + vertex.toString() + "] property [" + key + "] with value of [" + removedValue + "] removed in graph [" + graph.toString() + "]");
     }
 
-    public void vertexRemoved(final Vertex vertex) {
+    public void vertexRemoved(final Vertex vertex, Map<String, Object> props) {
         System.out.println("Vertex [" + vertex.toString() + "] removed from graph [" + graph.toString() + "]");
     }
 

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/GraphChangedListener.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/GraphChangedListener.java
@@ -3,6 +3,8 @@ package com.tinkerpop.blueprints.util.wrappers.event.listener;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 
+import java.util.Map;
+
 /**
  * Interface for a listener to EventGraph change events.
  * <p/>
@@ -43,7 +45,7 @@ public interface GraphChangedListener {
      *
      * @param vertex the vertex that was removed
      */
-    public void vertexRemoved(final Vertex vertex);
+    public void vertexRemoved(final Vertex vertex, Map<String, Object> props);
 
     /**
      * Raised after a new edge is added.

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/StubGraphChangedListener.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/StubGraphChangedListener.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.Vertex;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class StubGraphChangedListener implements GraphChangedListener {
     private int addEdgeEvent = 0;
@@ -50,7 +51,7 @@ public class StubGraphChangedListener implements GraphChangedListener {
         order.add("v-property-removed-" + vertex.getId() + "-" + s + ":" + o);
     }
 
-    public void vertexRemoved(Vertex vertex) {
+    public void vertexRemoved(Vertex vertex, Map<String, Object> props) {
         vertexRemovedEvent++;
         order.add("v-removed-" + vertex.getId());
     }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/VertexRemovedEvent.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/VertexRemovedEvent.java
@@ -3,19 +3,22 @@ package com.tinkerpop.blueprints.util.wrappers.event.listener;
 import com.tinkerpop.blueprints.Vertex;
 
 import java.util.Iterator;
+import java.util.Map;
 
 public class VertexRemovedEvent implements Event {
 
     private final Vertex vertex;
+    private final Map<String, Object> props;
 
-    public VertexRemovedEvent(Vertex vertex) {
+    public VertexRemovedEvent(Vertex vertex, Map<String, Object> props) {
         this.vertex = vertex;
+        this.props = props;
     }
 
     @Override
     public void fireEvent(Iterator<GraphChangedListener> eventListeners) {
         while (eventListeners.hasNext()) {
-            eventListeners.next().vertexRemoved(vertex);
+            eventListeners.next().vertexRemoved(vertex, props);
         }
     }
 }


### PR DESCRIPTION
This is required in order to read the removed element data after it has been removed when event is triggered.
