### PR TITLE
EventGraph: Expose removed element properties as a map as a part of the removed event.

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/EventGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/EventGraph.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.Features;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.GraphQuery;
 import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.ElementHelper;
 import com.tinkerpop.blueprints.util.StringFactory;
 import com.tinkerpop.blueprints.util.wrappers.WrappedGraphQuery;
 import com.tinkerpop.blueprints.util.wrappers.WrapperGraph;
@@ -17,6 +18,7 @@ import com.tinkerpop.blueprints.util.wrappers.event.listener.VertexRemovedEvent;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An EventGraph is a wrapper to existing Graph implementations and provides for graph events to be raised
@@ -74,16 +76,16 @@ public class EventGraph<T extends Graph> implements Graph, WrapperGraph<T> {
         this.trigger.addEvent(new VertexAddedEvent(vertex));
     }
 
-    protected void onVertexRemoved(final Vertex vertex) {
-        this.trigger.addEvent(new VertexRemovedEvent(vertex));
+    protected void onVertexRemoved(final Vertex vertex, Map<String, Object> props) {
+        this.trigger.addEvent(new VertexRemovedEvent(vertex, props));
     }
 
     protected void onEdgeAdded(Edge edge) {
         this.trigger.addEvent(new EdgeAddedEvent(edge));
     }
 
-    protected void onEdgeRemoved(final Edge edge) {
-        this.trigger.addEvent(new EdgeRemovedEvent(edge));
+    protected void onEdgeRemoved(final Edge edge, Map<String, Object> props) {
+        this.trigger.addEvent(new EdgeRemovedEvent(edge, props));
     }
 
     /**
@@ -117,8 +119,9 @@ public class EventGraph<T extends Graph> implements Graph, WrapperGraph<T> {
             vertexToRemove = ((EventVertex) vertex).getBaseVertex();
         }
 
+        Map<String, Object> props = ElementHelper.getProperties(vertex);
         this.baseGraph.removeVertex(vertexToRemove);
-        this.onVertexRemoved(vertex);
+        this.onVertexRemoved(vertex, props);
     }
 
     public Iterable<Vertex> getVertices() {
@@ -170,8 +173,9 @@ public class EventGraph<T extends Graph> implements Graph, WrapperGraph<T> {
             edgeToRemove = ((EventEdge) edge).getBaseEdge();
         }
 
+        Map<String, Object> props = ElementHelper.getProperties(edge);
         this.baseGraph.removeEdge(edgeToRemove);
-        this.onEdgeRemoved(edge);
+        this.onEdgeRemoved(edge, props);
     }
 
     public Iterable<Edge> getEdges() {

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/ConsoleGraphChangedListener.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/ConsoleGraphChangedListener.java
@@ -4,6 +4,8 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 
+import java.util.Map;
+
 /**
  * An example listener that writes a message to the console for each event that fires from the graph.
  *
@@ -29,7 +31,7 @@ public class ConsoleGraphChangedListener implements GraphChangedListener {
         System.out.println("Vertex [" + vertex.toString() + "] property [" + key + "] with value of [" + removedValue + "] removed in graph [" + graph.toString() + "]");
     }
 
-    public void vertexRemoved(final Vertex vertex) {
+    public void vertexRemoved(final Vertex vertex, Map<String, Object> props) {
         System.out.println("Vertex [" + vertex.toString() + "] removed from graph [" + graph.toString() + "]");
     }
 
@@ -45,7 +47,7 @@ public class ConsoleGraphChangedListener implements GraphChangedListener {
         System.out.println("Edge [" + edge.toString() + "] property [" + key + "] with value of [" + removedValue + "] removed in graph [" + graph.toString() + "]");
     }
 
-    public void edgeRemoved(final Edge edge) {
+    public void edgeRemoved(final Edge edge, Map<String, Object> props) {
         System.out.println("Edge [" + edge.toString() + "] removed from graph [" + graph.toString() + "]");
     }
 }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/EdgeRemovedEvent.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/EdgeRemovedEvent.java
@@ -4,19 +4,22 @@ package com.tinkerpop.blueprints.util.wrappers.event.listener;
 import com.tinkerpop.blueprints.Edge;
 
 import java.util.Iterator;
+import java.util.Map;
 
 public class EdgeRemovedEvent implements Event {
 
     private final Edge edge;
+    private final Map<String, Object> props;
 
-    public EdgeRemovedEvent(Edge edge) {
+    public EdgeRemovedEvent(Edge edge, Map<String, Object> props) {
         this.edge = edge;
+        this.props = props;
     }
 
     @Override
     public void fireEvent(Iterator<GraphChangedListener> eventListeners) {
         while (eventListeners.hasNext()) {
-            eventListeners.next().edgeRemoved(edge);
+            eventListeners.next().edgeRemoved(edge, props);
         }
     }
 }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/GraphChangedListener.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/GraphChangedListener.java
@@ -3,6 +3,8 @@ package com.tinkerpop.blueprints.util.wrappers.event.listener;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 
+import java.util.Map;
+
 /**
  * Interface for a listener to EventGraph change events.
  * <p/>
@@ -42,8 +44,9 @@ public interface GraphChangedListener {
      * Raised after a vertex was removed from the graph.
      *
      * @param vertex the vertex that was removed
+     * @param props the properties of the removed vertex
      */
-    public void vertexRemoved(final Vertex vertex);
+    public void vertexRemoved(final Vertex vertex, Map<String, Object> props);
 
     /**
      * Raised after a new edge is added.
@@ -73,7 +76,8 @@ public interface GraphChangedListener {
     /**
      * Raised after an edge was removed from the graph.
      *
-     * @param edge
+     * @param edge the edge that was removed.
+     * @param props the properties of the removed vertex
      */
-    public void edgeRemoved(final Edge edge);
+    public void edgeRemoved(final Edge edge, Map<String, Object> props);
 }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/StubGraphChangedListener.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/StubGraphChangedListener.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.Vertex;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class StubGraphChangedListener implements GraphChangedListener {
     private int addEdgeEvent = 0;
@@ -50,7 +51,7 @@ public class StubGraphChangedListener implements GraphChangedListener {
         order.add("v-property-removed-" + vertex.getId() + "-" + s + ":" + o);
     }
 
-    public void vertexRemoved(Vertex vertex) {
+    public void vertexRemoved(Vertex vertex, Map<String, Object> props) {
         vertexRemovedEvent++;
         order.add("v-removed-" + vertex.getId());
     }
@@ -70,7 +71,7 @@ public class StubGraphChangedListener implements GraphChangedListener {
         order.add("e-property-removed-" + edge.getId() + "-" + s + ":" + o);
     }
 
-    public void edgeRemoved(Edge edge) {
+    public void edgeRemoved(Edge edge, Map<String, Object> props) {
         edgeRemovedEvent++;
         order.add("e-removed-" + edge.getId());
     }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/VertexRemovedEvent.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/event/listener/VertexRemovedEvent.java
@@ -3,19 +3,22 @@ package com.tinkerpop.blueprints.util.wrappers.event.listener;
 import com.tinkerpop.blueprints.Vertex;
 
 import java.util.Iterator;
+import java.util.Map;
 
 public class VertexRemovedEvent implements Event {
 
     private final Vertex vertex;
+    private final Map<String, Object> props;
 
-    public VertexRemovedEvent(Vertex vertex) {
+    public VertexRemovedEvent(Vertex vertex, Map<String, Object> props) {
         this.vertex = vertex;
+        this.props = props;
     }
 
     @Override
     public void fireEvent(Iterator<GraphChangedListener> eventListeners) {
         while (eventListeners.hasNext()) {
-            eventListeners.next().vertexRemoved(vertex);
+            eventListeners.next().vertexRemoved(vertex, props);
         }
     }
 }


### PR DESCRIPTION
This is required in order to read the removed element data after it has been removed when event is triggered.
