### PR TITLE
Blueprints-DexGraph update to dexjava 4.8.0

### DIFF
--- a/blueprints-dex-graph/pom.xml
+++ b/blueprints-dex-graph/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.sparsity</groupId>
             <artifactId>dexjava</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>


### PR DESCRIPTION
I have updated the Dex driver for blueprints to the latest version of dexjava (4.8.0).
