### PR TITLE
Add graph.shutdown() call in a TransactionalGraph test method

### DIFF
--- a/blueprints-test/src/main/java/com/tinkerpop/blueprints/TransactionalGraphTestSuite.java
+++ b/blueprints-test/src/main/java/com/tinkerpop/blueprints/TransactionalGraphTestSuite.java
@@ -423,6 +423,7 @@ public class TransactionalGraphTestSuite extends TestSuite {
 
             assertEquals("marko", v1.getProperty("name"));
         }
+        graph.shutdown();
     }
 
     public void testBulkTransactionsOnEdges() {


### PR DESCRIPTION
The method testVertexPropertiesOnPreTransactionCommit() in
TransactionalGraphTestSuite generated a test graph but did not call
shutdown() on it.  I think omitting shutdown() is an error, but I
could be mistaken.  Every other method in the file that generates a
graph appears to call shutdown().  If this method really isn't
supposed to call shutdown(), then a comment noting it might be helpful
to future readers.

I found this when trying to upgrade Titan from Tinkerpop Stack 2.3.0
to 2.4.0-SNAPSHOT.  Omitting shutdown() caused errors during test
cleanup using a BDB TransactionalGraph implementation in Titan.

I'd like to investigate whether Titan-BDB could respond better or more
intuitively in this case, but I couldn't resist the lazy alternative of a
one-liner patch to add a shutdown() call in the test case.
