### PR TITLE
Create class before index

### DIFF
--- a/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
+++ b/blueprints-orient-graph/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
@@ -749,7 +749,7 @@ public abstract class OrientBaseGraph implements IndexableGraph, MetaGraph<OData
         if (className == null)
         	className = ancestorClassName;
 
-        final OClass cls = db.getMetadata().getSchema().getOrCreateClass(className, schema.getClass(ancestorClassName));
+        final OClass cls = schema.getOrCreateClass(className, schema.getClass(ancestorClassName));
         final OProperty property = cls.getProperty(key);
         if (property != null)
             keyType = property.getType();


### PR DESCRIPTION
If trying to define an index on a class that does not yet exist, create the class first, also specifying the correct ancestor.
