### PR TITLE
Updated pom.xml in blueprints-orient-graph to fix broken dependencies

### DIFF
--- a/blueprints-orient-graph/pom.xml
+++ b/blueprints-orient-graph/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-core</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orient-commons</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>


### PR DESCRIPTION
Orientdb bumped 1.4.1 to release, and blueprints no longer compiles without removing snapshot from the POM.

This simply changes the POM so that blueprints builds.
