### PR TITLE
use more generic java.lang.AutoCloseable instead of I/O related java.io....

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/CloseableIterable.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/CloseableIterable.java
@@ -1,13 +1,11 @@
 package com.tinkerpop.blueprints;
 
-import java.io.Closeable;
-
 /**
  * A CloseableIterable is required where it is necessary to deallocate resources from an Iterable.
  *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public interface CloseableIterable<T> extends Iterable<T>, Closeable {
+public interface CloseableIterable<T> extends Iterable<T>, AutoCloseable {
 
     /**
      * Release the resources of the iterator.


### PR DESCRIPTION
CloseableIterable should implement java.lang.AutoCloseable, as java.io.Closeable is only meant for I/O related stuff (like Streams) and therefore throws IOException (which is not appropriate for Graphs). AutoCloseable also supports all the fancy syntactic sugar, just without the I/O focus.
