### PR TITLE
batch-loading vertex cache refactoring and optimizations

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/AbstractIDVertexCache.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/AbstractIDVertexCache.java
@@ -1,0 +1,56 @@
+package com.tinkerpop.blueprints.util.wrappers.batch.cache;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.tinkerpop.blueprints.Vertex;
+
+abstract class AbstractIDVertexCache implements VertexCache {
+
+    static final int INITIAL_CAPACITY = 1000;
+    static final int INITIAL_TX_CAPACITY = 100;
+
+    private final Map<Object, Object> map;
+    private final Set<Object> mapKeysInCurrentTx;
+
+    AbstractIDVertexCache() {
+        map = new HashMap<Object, Object>(INITIAL_CAPACITY);
+        mapKeysInCurrentTx = new HashSet<Object>(INITIAL_TX_CAPACITY);
+    }
+
+    @Override
+    public Object getEntry(Object externalId) {
+        return map.get(externalId);
+    }
+
+    @Override
+    public void set(Vertex vertex, Object externalId) {
+        setId(vertex, externalId);
+    }
+
+    @Override
+    public void setId(Object vertexId, Object externalId) {
+        map.put(externalId, vertexId);
+        mapKeysInCurrentTx.add(externalId);
+    }
+
+    @Override
+    public boolean contains(Object externalId) {
+        return map.containsKey(externalId);
+    }
+
+    @Override
+    public void newTransaction() {
+        for (Object id : mapKeysInCurrentTx) {
+            Object o = map.get(id);
+            assert null != o;
+            if (o instanceof Vertex) {
+                Vertex v = (Vertex)o;
+                map.put(id, v.getId());
+            }
+        }
+        mapKeysInCurrentTx.clear();
+    }
+}

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/LongIDVertexCache.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/LongIDVertexCache.java
@@ -1,9 +1,11 @@
 package com.tinkerpop.blueprints.util.wrappers.batch.cache;
 
-import cern.colt.function.LongObjectProcedure;
+import cern.colt.function.LongProcedure;
+import cern.colt.list.AbstractLongList;
+import cern.colt.list.LongArrayList;
 import cern.colt.map.AbstractLongObjectMap;
 import cern.colt.map.OpenLongObjectHashMap;
-import com.tinkerpop.blueprints.Graph;
+
 import com.tinkerpop.blueprints.Vertex;
 
 /**
@@ -12,12 +14,14 @@ import com.tinkerpop.blueprints.Vertex;
 
 public class LongIDVertexCache implements VertexCache {
 
-    private static final int INITIAL_CAPACITY = 1000;
-
     private final AbstractLongObjectMap map;
+    private final AbstractLongList mapKeysInCurrentTx;
+    private final LongProcedure newTransactionProcedure;
 
     public LongIDVertexCache() {
-        map = new OpenLongObjectHashMap(INITIAL_CAPACITY);
+        map = new OpenLongObjectHashMap(AbstractIDVertexCache.INITIAL_CAPACITY);
+        mapKeysInCurrentTx = new LongArrayList(AbstractIDVertexCache.INITIAL_TX_CAPACITY);
+        newTransactionProcedure = new VertexConverterLP();
     }
 
     private static final long getID(Object externalID) {
@@ -25,11 +29,9 @@ public class LongIDVertexCache implements VertexCache {
         return ((Number) externalID).longValue();
     }
 
-
     @Override
     public Object getEntry(Object externalId) {
-        long id = getID(externalId);
-        return map.get(id);
+        return map.get(getID(externalId));
     }
 
     @Override
@@ -41,6 +43,7 @@ public class LongIDVertexCache implements VertexCache {
     public void setId(Object vertexId, Object externalId) {
         long id = getID(externalId);
         map.put(id, vertexId);
+        mapKeysInCurrentTx.add(id);
     }
 
     @Override
@@ -50,14 +53,32 @@ public class LongIDVertexCache implements VertexCache {
 
     @Override
     public void newTransaction() {
-        map.forEachPair(new LongObjectProcedure() {
-            @Override
-            public boolean apply(long l, Object o) {
-                if (o instanceof Vertex) {
-                    map.put(l, ((Vertex) o).getId());
-                }
-                return true;
+        mapKeysInCurrentTx.forEach(newTransactionProcedure);
+        mapKeysInCurrentTx.clear();
+    }
+
+    /**
+     * See {@link LongIDVertexCache#newTransaction()}
+     */
+    private class VertexConverterLP implements LongProcedure {
+        
+        /**
+         * Retrieve the Object associated with each long from {@code map}. If it
+         * is an {@code instanceof Vertex}, then replace it in the map with
+         * {@link Vertex#getId()}. Otherwise, do nothing. Always returns true.
+         * 
+         * @param l
+         *            Colt long list element
+         * @return true
+         */
+        @Override
+        public final boolean apply(final long l) {
+            final Object o = map.get(l);
+            assert null != o;
+            if (o instanceof Vertex) {
+                map.put(l, ((Vertex) o).getId());
             }
-        });
+            return true; // tell forEach to apply us to next long
+        }
     }
 }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/ObjectIDVertexCache.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/ObjectIDVertexCache.java
@@ -1,54 +1,8 @@
 package com.tinkerpop.blueprints.util.wrappers.batch.cache;
 
-import com.tinkerpop.blueprints.Graph;
-import com.tinkerpop.blueprints.Vertex;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * (c) Matthias Broecheler (me@matthiasb.com)
  */
 
-public class ObjectIDVertexCache implements VertexCache {
-
-    private static final int INITIAL_CAPACITY = 1000;
-
-    private final Map<Object, Object> map;
-
-    public ObjectIDVertexCache() {
-        map = new HashMap<Object, Object>(INITIAL_CAPACITY);
-    }
-
-
-    @Override
-    public Object getEntry(Object externalId) {
-        return map.get(externalId);
-    }
-
-    @Override
-    public void set(Vertex vertex, Object externalId) {
-        setId(vertex,externalId);
-    }
-
-    @Override
-    public void setId(Object vertexId, Object externalId) {
-        map.put(externalId, vertexId);
-    }
-
-    @Override
-    public boolean contains(Object externalId) {
-        return map.containsKey(externalId);
-    }
-
-
-    @Override
-    public void newTransaction() {
-        for (Map.Entry<Object, Object> entry : map.entrySet()) {
-            if (entry.getValue() instanceof Vertex) {
-                Vertex v = (Vertex) entry.getValue();
-                entry.setValue(v.getId());
-            }
-        }
-    }
-}
+public class ObjectIDVertexCache extends AbstractIDVertexCache { }

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/StringIDVertexCache.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/batch/cache/StringIDVertexCache.java
@@ -1,31 +1,20 @@
 package com.tinkerpop.blueprints.util.wrappers.batch.cache;
 
-import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * (c) Matthias Broecheler (me@matthiasb.com)
  */
 
-public class StringIDVertexCache implements VertexCache {
+public class StringIDVertexCache extends AbstractIDVertexCache {
 
-    private static final int INITIAL_CAPACITY = 1000;
-    private static final int INITIAL_TX_CAPACITY = 100;
-
-    private final Map<String, Object> map;
-    private final Set<String> mapKeysInCurrentTx;
     private final StringCompression compression;
 
     public StringIDVertexCache(final StringCompression compression) {
+        super();
         if (compression == null) throw new IllegalArgumentException("Compression expected.");
         this.compression = compression;
-        map = new HashMap<String, Object>(INITIAL_CAPACITY);
-        mapKeysInCurrentTx = new HashSet<String>(INITIAL_TX_CAPACITY);
     }
 
     public StringIDVertexCache() {
@@ -34,37 +23,16 @@ public class StringIDVertexCache implements VertexCache {
 
     @Override
     public Object getEntry(Object externalId) {
-        String id = compression.compress(externalId.toString());
-        return map.get(id);
-    }
-
-    @Override
-    public void set(Vertex vertex, Object externalId) {
-        setId(vertex,externalId);
+        return super.getEntry(compression.compress(externalId.toString()));
     }
 
     @Override
     public void setId(Object vertexId, Object externalId) {
-        String id = compression.compress(externalId.toString());
-        map.put(id, vertexId);
-        mapKeysInCurrentTx.add(id);
+        super.setId(vertexId, compression.compress(externalId.toString()));
     }
 
     @Override
     public boolean contains(Object externalId) {
-        return map.containsKey(compression.compress(externalId.toString()));
-    }
-
-    @Override
-    public void newTransaction() {
-        for (String id : mapKeysInCurrentTx) {
-            Object o = map.get(id);
-            assert null != o;
-            if (o instanceof Vertex) {
-                Vertex v = (Vertex)o;
-                map.put(id, v.getId());
-            }
-        }
-        mapKeysInCurrentTx.clear();
+        return super.contains(compression.compress(externalId.toString()));
     }
 }


### PR DESCRIPTION
I deduplicated some code in the vertex caching part of the graph batch loader without changing the VertexCache interface.  I also optimized the vertex cache implementations to eliminate redundant work on commit. When loading the SNAP Amazon dataset for graphlab with StringIDVertexCache and 10k batch size, this cut walltime time from 25 to slightly under 20 minutes. 

The test suite exercises all three concrete vertex cache implementations.  They pass their JUnit tests on my box.  However, I've only used the StringIDVertexCache implementation with a nontrivial dataset (SNAP Amazon).  The others are untested besides the unit suite.  If you don't like the refactoring which I sort of hurried through, then you might want to consider just a0cf0f1 alone, which is a single-file optimization commit that attempts no refactoring.  I could make another PR for just that commit.
