### PR TITLE
updated dependancy for OrientDB

### DIFF
--- a/blueprints-orient-graph/pom.xml
+++ b/blueprints-orient-graph/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<javac.src.version>1.6</javac.src.version>
 		<javac.target.version>1.6</javac.target.version>
-		<orientdb.version>1.5.1-SNAPSHOT</orientdb.version>
+		<orientdb.version>1.6.0-SNAPSHOT</orientdb.version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
OrientDB 1.5.1-SNAPSHOT is no longer available, since it has been released 1.5.1 .
OrientDB 1.6.0-SNAPSHOT is the current snapshot.
