### PR TITLE
ElementHelper.areEquals should not compare classes

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/ElementHelper.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/ElementHelper.java
@@ -193,8 +193,6 @@ public class ElementHelper {
             return true;
         if (null == b)
             return false;
-        if (!a.getClass().equals(b.getClass()))
-            return false;
         return a.getId().equals(((Element) b).getId());
     }
 


### PR DESCRIPTION
Vertex and TinkerVertex might represent the same thing, therefor we shouldn't be comparing the classes, and instead rely on the equals implementation of the elements. 
