### PR TITLE
Update OrientDB version in order to compile

### DIFF
--- a/blueprints-orient-graph/pom.xml
+++ b/blueprints-orient-graph/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.tinkerpop.blueprints</groupId>
 		<artifactId>blueprints</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>1.6.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>blueprints-orient-graph</artifactId>


### PR DESCRIPTION
Since that the version 2.0-SNAPSHOT are not available, the last available version (1.6.2) is required to compile.
