### PR TITLE
Update OrientDB version in order to compile

### DIFF
--- a/blueprints-orient-graph/pom.xml
+++ b/blueprints-orient-graph/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<javac.src.version>1.6</javac.src.version>
 		<javac.target.version>1.6</javac.target.version>
-		<orientdb.version>2.0-SNAPSHOT</orientdb.version>
+		<orientdb.version>1.6.2</orientdb.version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
Since that the version 2.0-SNAPSHOT is not available, the last available version (1.6.2) is required to compile. This pull request is a replacement for the wrong #454.
