### PR TITLE
Upgrade to Neo4j 2.0

### DIFF
--- a/blueprints-neo4j2-graph/pom.xml
+++ b/blueprints-neo4j2-graph/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.tinkerpop.blueprints</groupId>
+        <artifactId>blueprints</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>blueprints-neo4j2-graph</artifactId>
+    <name>Blueprints-Neo4jGraph</name>
+    <description>Blueprints property graph implementation for the Neo4j graph database</description>
+    <dependencies>
+        <dependency>
+            <groupId>com.tinkerpop.blueprints</groupId>
+            <artifactId>blueprints-core</artifactId>
+            <version>${blueprints.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j</artifactId>
+            <version>2.0.0</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-ha</artifactId>
+            <version>2.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-management</artifactId>
+            <version>2.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tinkerpop.blueprints</groupId>
+            <artifactId>blueprints-test</artifactId>
+            <version>${blueprints.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <directory>${basedir}/target</directory>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources
+                </directory>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/src/test/resources
+                </directory>
+            </testResource>
+        </testResources>
+    </build>
+</project>

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jEdge.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jEdge.java
@@ -1,0 +1,46 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.ExceptionFactory;
+import com.tinkerpop.blueprints.util.StringFactory;
+import org.neo4j.graphdb.Relationship;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jEdge extends Neo4jElement implements Edge {
+
+    public Neo4jEdge(final Relationship relationship, final Neo4jGraph graph) {
+        super(graph);
+        this.rawElement = relationship;
+    }
+
+    public String getLabel() {
+        return ((Relationship) this.rawElement).getType().name();
+    }
+
+    public Vertex getVertex(final Direction direction) {
+        if (direction.equals(Direction.OUT))
+            return new Neo4jVertex(((Relationship) this.rawElement).getStartNode(), this.graph);
+        else if (direction.equals(Direction.IN))
+            return new Neo4jVertex(((Relationship) this.rawElement).getEndNode(), this.graph);
+        else
+            throw ExceptionFactory.bothIsNotSupported();
+
+    }
+
+    public boolean equals(final Object object) {
+        return object instanceof Neo4jEdge && ((Neo4jEdge) object).getId().equals(this.getId());
+    }
+
+    public String toString() {
+        return StringFactory.edgeString(this);
+    }
+
+    public Relationship getRawEdge() {
+        return (Relationship) this.rawElement;
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jEdgeIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jEdgeIterable.java
@@ -1,0 +1,93 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Edge;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.index.IndexHits;
+
+import java.util.Iterator;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jEdgeIterable<T extends Edge> implements CloseableIterable<Neo4jEdge> {
+
+    private final Iterable<Relationship> relationships;
+    private final Neo4jGraph graph;
+    private final boolean checkTransaction;
+    private static final String DUMMY_PROPERTY = "a";
+
+    public Neo4jEdgeIterable(final Iterable<Relationship> relationships, final Neo4jGraph graph, final boolean checkTransaction) {
+        this.relationships = relationships;
+        this.graph = graph;
+        this.checkTransaction = checkTransaction;
+    }
+
+    public Neo4jEdgeIterable(final Iterable<Relationship> relationships, final Neo4jGraph graph) {
+        this(relationships, graph, false);
+    }
+
+    public Iterator<Neo4jEdge> iterator() {
+        return new Iterator<Neo4jEdge>() {
+            private final Iterator<Relationship> itty = relationships.iterator();
+            private Relationship nextRelationship = null;
+
+            public void remove() {
+                this.itty.remove();
+            }
+
+            public Neo4jEdge next() {
+                if (!checkTransaction) {
+                    return new Neo4jEdge(this.itty.next(), graph);
+                } else {
+                    if (null != this.nextRelationship) {
+                        final Relationship temp = this.nextRelationship;
+                        this.nextRelationship = null;
+                        return new Neo4jEdge(temp, graph);
+                    } else {
+                        while (true) {
+                            final Relationship relationship = this.itty.next();
+                            try {
+                                if (!graph.relationshipIsDeleted(relationship.getId())) {
+                                    return new Neo4jEdge(relationship, graph);
+                                }
+                            } catch (final IllegalStateException e) {
+                                // tried to access a relationship not available to the transaction
+                            }
+                        }
+                    }
+                }
+            }
+
+            public boolean hasNext() {
+                if (!checkTransaction)
+                    return this.itty.hasNext();
+                else {
+                    if (null != this.nextRelationship)
+                        return true;
+                    else {
+                        while (this.itty.hasNext()) {
+                            final Relationship relationship = this.itty.next();
+                            try {
+                                if (!graph.relationshipIsDeleted(relationship.getId())) {
+                                    this.nextRelationship = relationship;
+                                    return true;
+                                }
+                            } catch (final IllegalStateException e) {
+                            }
+                        }
+                        return false;
+                    }
+
+                }
+            }
+        };
+    }
+
+    public void close() {
+        if (this.relationships instanceof IndexHits) {
+            ((IndexHits) this.relationships).close();
+        }
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jElement.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jElement.java
@@ -1,0 +1,134 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.ElementHelper;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+abstract class Neo4jElement implements Element {
+
+    protected final Neo4jGraph graph;
+    protected PropertyContainer rawElement;
+
+    public Neo4jElement(final Neo4jGraph graph) {
+        this.graph = graph;
+    }
+
+    public <T> T getProperty(final String key) {
+        if (this.rawElement.hasProperty(key))
+            return (T) tryConvertCollectionToArrayList(this.rawElement.getProperty(key));
+        else
+            return null;
+    }
+
+    public void setProperty(final String key, final Object value) {
+        ElementHelper.validateProperty(this, key, value);
+        this.graph.autoStartTransaction();
+        // attempts to take a collection and convert it to an array so that Neo4j can consume it
+        this.rawElement.setProperty(key, tryConvertCollectionToArray(value));
+    }
+
+    public <T> T removeProperty(final String key) {
+        if (!this.rawElement.hasProperty(key))
+            return null;
+        else {
+            this.graph.autoStartTransaction();
+            return (T) this.rawElement.removeProperty(key);
+        }
+    }
+
+    public Set<String> getPropertyKeys() {
+        final Set<String> keys = new HashSet<String>();
+        for (final String key : this.rawElement.getPropertyKeys()) {
+            keys.add(key);
+        }
+        return keys;
+    }
+
+    public int hashCode() {
+        return this.getId().hashCode();
+    }
+
+    public PropertyContainer getRawElement() {
+        return this.rawElement;
+    }
+
+    public Object getId() {
+        if (this.rawElement instanceof Node) {
+            return ((Node) this.rawElement).getId();
+        } else {
+            return ((Relationship) this.rawElement).getId();
+        }
+    }
+
+    public void remove() {
+        if (this instanceof Vertex)
+            this.graph.removeVertex((Vertex) this);
+        else
+            this.graph.removeEdge((Edge) this);
+    }
+
+    public boolean equals(final Object object) {
+        return ElementHelper.areEqual(this, object);
+    }
+
+    private Object tryConvertCollectionToArray(final Object value) {
+        if (value instanceof Collection<?>) {
+            // convert this collection to an array.  the collection must
+            // be all of the same type.
+            try {
+                final Collection<?> collection = (Collection<?>) value;
+                Object[] array = null;
+                final Iterator<?> objects = collection.iterator();
+                for (int i = 0; objects.hasNext(); i++) {
+                    Object object = objects.next();
+                    if (array == null) {
+                        array = (Object[]) Array.newInstance(object.getClass(), collection.size());
+                    }
+
+                    array[i] = object;
+                }
+                return array;
+            } catch (final ArrayStoreException ase) {
+                // this fires off if the collection is not all of the same type
+                return value;
+            }
+        } else {
+            return value;
+        }
+    }
+
+    private Object tryConvertCollectionToArrayList(final Object value) {
+        if (value.getClass().isArray()) {
+            // convert primitive array to an ArrayList.  
+            try {
+                ArrayList<Object> list = new ArrayList<Object>();
+                int arrlength = Array.getLength(value);
+                for (int i = 0; i < arrlength; i++) {
+                    Object object = Array.get(value, i);
+                    list.add(object);
+                }
+                return list;
+            } catch (final Exception e) {
+                // this fires off if the collection is not an array
+                return value;
+            }
+        } else {
+            return value;
+        }
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraph.java
@@ -1,0 +1,590 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Features;
+import com.tinkerpop.blueprints.GraphQuery;
+import com.tinkerpop.blueprints.Index;
+import com.tinkerpop.blueprints.IndexableGraph;
+import com.tinkerpop.blueprints.KeyIndexableGraph;
+import com.tinkerpop.blueprints.MetaGraph;
+import com.tinkerpop.blueprints.Parameter;
+import com.tinkerpop.blueprints.TransactionalGraph;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.DefaultGraphQuery;
+import com.tinkerpop.blueprints.util.ExceptionFactory;
+import com.tinkerpop.blueprints.util.KeyIndexableGraphHelper;
+import com.tinkerpop.blueprints.util.PropertyFilteredIterable;
+import com.tinkerpop.blueprints.util.StringFactory;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationConverter;
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.index.AutoIndexer;
+import org.neo4j.graphdb.index.RelationshipIndex;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A Blueprints implementation of the graph database Neo4j (http://neo4j.org)
+ *
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jGraph implements TransactionalGraph, IndexableGraph, KeyIndexableGraph, MetaGraph<GraphDatabaseService> {
+    private static final Logger logger = Logger.getLogger(Neo4jGraph.class.getName());
+
+    private GraphDatabaseService rawGraph;
+    private static final String INDEXED_KEYS_POSTFIX = ":indexed_keys";
+
+    protected final ThreadLocal<Transaction> tx = new ThreadLocal<Transaction>() {
+        protected Transaction initialValue() {
+            return null;
+        }
+    };
+
+    protected final ThreadLocal<Boolean> checkElementsInTransaction = new ThreadLocal<Boolean>() {
+        protected Boolean initialValue() {
+            return false;
+        }
+    };
+
+    private static final Features FEATURES = new Features();
+
+    static {
+
+        FEATURES.supportsSerializableObjectProperty = false;
+        FEATURES.supportsBooleanProperty = true;
+        FEATURES.supportsDoubleProperty = true;
+        FEATURES.supportsFloatProperty = true;
+        FEATURES.supportsIntegerProperty = true;
+        FEATURES.supportsPrimitiveArrayProperty = true;
+        FEATURES.supportsUniformListProperty = true;
+        FEATURES.supportsMixedListProperty = false;
+        FEATURES.supportsLongProperty = true;
+        FEATURES.supportsMapProperty = false;
+        FEATURES.supportsStringProperty = true;
+
+        FEATURES.supportsDuplicateEdges = true;
+        FEATURES.supportsSelfLoops = true;
+        FEATURES.isPersistent = true;
+        FEATURES.isWrapper = false;
+        FEATURES.supportsVertexIteration = true;
+        FEATURES.supportsEdgeIteration = true;
+        FEATURES.supportsVertexIndex = true;
+        FEATURES.supportsEdgeIndex = true;
+        FEATURES.ignoresSuppliedIds = true;
+        FEATURES.supportsTransactions = true;
+        FEATURES.supportsIndices = true;
+        FEATURES.supportsKeyIndices = true;
+        FEATURES.supportsVertexKeyIndex = true;
+        FEATURES.supportsEdgeKeyIndex = true;
+        FEATURES.supportsEdgeRetrieval = true;
+        FEATURES.supportsVertexProperties = true;
+        FEATURES.supportsEdgeProperties = true;
+        FEATURES.supportsThreadedTransactions = false;
+    }
+
+    private final TransactionManager transactionManager;
+    private final ExecutionEngine cypher;
+
+    protected boolean checkElementsInTransaction() {
+        if (this.tx.get() == null) {
+            return false;
+        } else {
+            return this.checkElementsInTransaction.get();
+        }
+    }
+
+    /**
+     * Neo4j's transactions are not consistent between the graph and the graph
+     * indices. Moreover, global graph operations are not consistent. For
+     * example, if a vertex is removed and then an index is queried in the same
+     * transaction, the removed vertex can be returned. This method allows the
+     * developer to turn on/off a Neo4jGraph 'hack' that ensures transactional
+     * consistency. The default behavior for Neo4jGraph is to use Neo4j's native
+     * behavior which ensures speed at the expensive of consistency. Note that
+     * this boolean switch is local to the current thread (i.e. a ThreadLocal
+     * variable).
+     *
+     * @param checkElementsInTransaction check whether an element is in the transaction between
+     *                                   returning it
+     */
+    public void setCheckElementsInTransaction(final boolean checkElementsInTransaction) {
+        this.checkElementsInTransaction.set(checkElementsInTransaction);
+    }
+
+    public Neo4jGraph(final String directory) {
+        this(directory, null);
+    }
+
+    public Neo4jGraph(final GraphDatabaseService rawGraph) {
+        this.rawGraph = rawGraph;
+
+        transactionManager = ((GraphDatabaseAPI) rawGraph).getDependencyResolver().resolveDependency(TransactionManager.class);
+
+        cypher = new ExecutionEngine(rawGraph);
+        init();
+    }
+
+    public Neo4jGraph(final String directory, final Map<String, String> configuration) {
+        try {
+            GraphDatabaseBuilder builder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(directory);
+            if (null != configuration)
+                this.rawGraph = builder.setConfig(configuration).newGraphDatabase();
+            else
+                this.rawGraph = builder.newGraphDatabase();
+
+            transactionManager = ((GraphDatabaseAPI) rawGraph).getDependencyResolver().resolveDependency(TransactionManager.class);
+            cypher = new ExecutionEngine(rawGraph);
+
+            init();
+
+        } catch (Exception e) {
+            if (this.rawGraph != null)
+                this.rawGraph.shutdown();
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    protected void init() {
+        this.loadKeyIndices();
+    }
+
+    public Neo4jGraph(final Configuration configuration) {
+        this(configuration.getString("blueprints.neo4j.directory", null),
+                ConfigurationConverter.getMap(configuration.subset("blueprints.neo4j.conf")));
+    }
+
+    private void loadKeyIndices() {
+        this.autoStartTransaction();
+        for (final String key : this.getInternalIndexKeys(Vertex.class)) {
+            this.createKeyIndex(key, Vertex.class);
+        }
+        for (final String key : this.getInternalIndexKeys(Edge.class)) {
+            this.createKeyIndex(key, Edge.class);
+        }
+        this.commit();
+    }
+
+    private <T extends Element> void createInternalIndexKey(final String key, final Class<T> elementClass) {
+        final String propertyName = elementClass.getSimpleName() + INDEXED_KEYS_POSTFIX;
+        if (rawGraph instanceof GraphDatabaseAPI) {
+            final PropertyContainer pc = getGraphProperties();
+            try {
+                final String[] keys = (String[]) pc.getProperty(propertyName);
+                final Set<String> temp = new HashSet<String>(Arrays.asList(keys));
+                temp.add(key);
+                pc.setProperty(propertyName, temp.toArray(new String[temp.size()]));
+            } catch (Exception e) {
+                // no indexed_keys kernel data property
+                pc.setProperty(propertyName, new String[]{key});
+
+            }
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unable to create an index on a non-GraphDatabaseAPI graph");
+        }
+    }
+
+    private <T extends Element> void dropInternalIndexKey(final String key, final Class<T> elementClass) {
+        final String propertyName = elementClass.getSimpleName() + INDEXED_KEYS_POSTFIX;
+        if (rawGraph instanceof GraphDatabaseAPI) {
+            final PropertyContainer pc = getGraphProperties();
+            try {
+                final String[] keys = (String[]) pc.getProperty(propertyName);
+                final Set<String> temp = new HashSet<String>(Arrays.asList(keys));
+                temp.remove(key);
+                pc.setProperty(propertyName, temp.toArray(new String[temp.size()]));
+            } catch (Exception e) {
+                // no indexed_keys kernel data property
+            }
+        } else {
+            logNotGraphDatabaseAPI();
+        }
+    }
+
+    public <T extends Element> Set<String> getInternalIndexKeys(final Class<T> elementClass) {
+        final String propertyName = elementClass.getSimpleName() + INDEXED_KEYS_POSTFIX;
+        if (rawGraph instanceof GraphDatabaseAPI) {
+            final PropertyContainer pc = getGraphProperties();
+            try {
+                final String[] keys = (String[]) pc.getProperty(propertyName);
+                return new HashSet<String>(Arrays.asList(keys));
+            } catch (Exception e) {
+                // no indexed_keys kernel data property
+            }
+        } else {
+            logNotGraphDatabaseAPI();
+        }
+        return Collections.emptySet();
+    }
+
+    private PropertyContainer getGraphProperties() {
+        return ((GraphDatabaseAPI) this.rawGraph).getDependencyResolver().resolveDependency(NodeManager.class).getGraphProperties();
+    }
+
+    private void logNotGraphDatabaseAPI() {
+        if (logger.isLoggable(Level.WARNING)) {
+            logger.log(Level.WARNING, "Indices are not available on non-GraphDatabaseAPI instances" +
+                    " Current graph class is " + rawGraph.getClass().getName());
+        }
+    }
+
+    public synchronized <T extends Element> Index<T> createIndex(final String indexName, final Class<T> indexClass, final Parameter... indexParameters) {
+        if (this.rawGraph.index().existsForNodes(indexName) || this.rawGraph.index().existsForRelationships(indexName)) {
+            throw ExceptionFactory.indexAlreadyExists(indexName);
+        }
+        this.autoStartTransaction();
+        return new Neo4jIndex(indexName, indexClass, this, indexParameters);
+    }
+
+    public <T extends Element> Index<T> getIndex(final String indexName, final Class<T> indexClass) {
+        if (Vertex.class.isAssignableFrom(indexClass)) {
+            if (this.rawGraph.index().existsForNodes(indexName)) {
+                return new Neo4jIndex(indexName, indexClass, this);
+            } else if (this.rawGraph.index().existsForRelationships(indexName)) {
+                throw ExceptionFactory.indexDoesNotSupportClass(indexName, indexClass);
+            } else {
+                return null;
+            }
+        } else if (Edge.class.isAssignableFrom(indexClass)) {
+            if (this.rawGraph.index().existsForRelationships(indexName)) {
+                return new Neo4jIndex(indexName, indexClass, this);
+            } else if (this.rawGraph.index().existsForNodes(indexName)) {
+                throw ExceptionFactory.indexDoesNotSupportClass(indexName, indexClass);
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Note that this method will force a successful closing of the current
+     * thread's transaction. As such, once the index is dropped, the operation
+     * is committed.
+     *
+     * @param indexName the name of the index to drop
+     */
+    public synchronized void dropIndex(final String indexName) {
+        this.autoStartTransaction();
+        if (this.rawGraph.index().existsForNodes(indexName)) {
+            org.neo4j.graphdb.index.Index<Node> nodeIndex = this.rawGraph.index().forNodes(indexName);
+            if (nodeIndex.isWriteable()) {
+                nodeIndex.delete();
+            }
+        } else if (this.rawGraph.index().existsForRelationships(indexName)) {
+            RelationshipIndex relationshipIndex = this.rawGraph.index().forRelationships(indexName);
+            if (relationshipIndex.isWriteable()) {
+                relationshipIndex.delete();
+            }
+        }
+        this.commit();
+    }
+
+    public Iterable<Index<? extends Element>> getIndices() {
+        final List<Index<? extends Element>> indices = new ArrayList<Index<? extends Element>>();
+        for (final String name : this.rawGraph.index().nodeIndexNames()) {
+            if (!name.equals(Neo4jTokens.NODE_AUTO_INDEX))
+                indices.add(new Neo4jIndex(name, Vertex.class, this));
+        }
+        for (final String name : this.rawGraph.index().relationshipIndexNames()) {
+            if (!name.equals(Neo4jTokens.RELATIONSHIP_AUTO_INDEX))
+                indices.add(new Neo4jIndex(name, Edge.class, this));
+        }
+        return indices;
+    }
+
+    public Neo4jVertex addVertex(final Object id) {
+        this.autoStartTransaction();
+        return new Neo4jVertex(this.rawGraph.createNode(), this);
+    }
+
+    public Neo4jVertex getVertex(final Object id) {
+        if (null == id)
+            throw ExceptionFactory.vertexIdCanNotBeNull();
+
+        try {
+            final Long longId;
+            if (id instanceof Long)
+                longId = (Long) id;
+            else if (id instanceof Number)
+                longId = ((Number) id).longValue();
+            else
+                longId = Double.valueOf(id.toString()).longValue();
+            return new Neo4jVertex(this.rawGraph.getNodeById(longId), this);
+        } catch (NotFoundException e) {
+            return null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The underlying Neo4j graph does not natively support this method within a
+     * transaction. If the graph is not currently in a transaction, then the
+     * operation runs efficiently and correctly. If the graph is currently in a
+     * transaction, please use setCheckElementsInTransaction() if it is
+     * necessary to ensure proper transactional semantics. Note that it is
+     * costly to check if an element is in the transaction.
+     *
+     * @return all the vertices in the graph
+     */
+    public Iterable<Vertex> getVertices() {
+        return new Neo4jVertexIterable(GlobalGraphOperations.at(rawGraph).getAllNodes(), this, this.checkElementsInTransaction());
+    }
+
+    public Iterable<Vertex> getVertices(final String key, final Object value) {
+        final AutoIndexer indexer = this.rawGraph.index().getNodeAutoIndexer();
+        if (indexer.isEnabled() && indexer.getAutoIndexedProperties().contains(key))
+            return new Neo4jVertexIterable(this.rawGraph.index().getNodeAutoIndexer().getAutoIndex().get(key, value), this, this.checkElementsInTransaction());
+        else
+            return new PropertyFilteredIterable<Vertex>(key, value, this.getVertices());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The underlying Neo4j graph does not natively support this method within a
+     * transaction. If the graph is not currently in a transaction, then the
+     * operation runs efficiently and correctly. If the graph is currently in a
+     * transaction, please use setCheckElementsInTransaction() if it is
+     * necessary to ensure proper transactional semantics. Note that it is
+     * costly to check if an element is in the transaction.
+     *
+     * @return all the edges in the graph
+     */
+    public Iterable<Edge> getEdges() {
+        return new Neo4jEdgeIterable(GlobalGraphOperations.at(rawGraph).getAllRelationships(), this, this.checkElementsInTransaction());
+    }
+
+    public Iterable<Edge> getEdges(final String key, final Object value) {
+        final AutoIndexer indexer = this.rawGraph.index().getRelationshipAutoIndexer();
+        if (indexer.isEnabled() && indexer.getAutoIndexedProperties().contains(key))
+            return new Neo4jEdgeIterable(this.rawGraph.index().getRelationshipAutoIndexer().getAutoIndex().get(key, value), this,
+                    this.checkElementsInTransaction());
+        else
+            return new PropertyFilteredIterable<Edge>(key, value, this.getEdges());
+    }
+
+    public <T extends Element> void dropKeyIndex(final String key, final Class<T> elementClass) {
+        if (elementClass == null)
+            throw ExceptionFactory.classForElementCannotBeNull();
+
+        this.autoStartTransaction();
+        if (Vertex.class.isAssignableFrom(elementClass)) {
+            if (!this.rawGraph.index().getNodeAutoIndexer().isEnabled())
+                return;
+            this.rawGraph.index().getNodeAutoIndexer().stopAutoIndexingProperty(key);
+        } else if (Edge.class.isAssignableFrom(elementClass)) {
+            if (!this.rawGraph.index().getRelationshipAutoIndexer().isEnabled())
+                return;
+            this.rawGraph.index().getRelationshipAutoIndexer().stopAutoIndexingProperty(key);
+        } else {
+            throw ExceptionFactory.classIsNotIndexable(elementClass);
+        }
+        this.dropInternalIndexKey(key, elementClass);
+    }
+
+    public <T extends Element> void createKeyIndex(final String key, final Class<T> elementClass, final Parameter... indexParameters) {
+        if (elementClass == null)
+            throw ExceptionFactory.classForElementCannotBeNull();
+
+        if (Vertex.class.isAssignableFrom(elementClass)) {
+            this.autoStartTransaction();
+            if (!this.rawGraph.index().getNodeAutoIndexer().isEnabled())
+                this.rawGraph.index().getNodeAutoIndexer().setEnabled(true);
+
+            this.rawGraph.index().getNodeAutoIndexer().startAutoIndexingProperty(key);
+            if (!this.getInternalIndexKeys(Vertex.class).contains(key)) {
+
+                KeyIndexableGraphHelper.reIndexElements(this, this.getVertices(), new HashSet<String>(Arrays.asList(key)));
+                this.autoStartTransaction();
+                this.createInternalIndexKey(key, elementClass);
+            }
+        } else if (Edge.class.isAssignableFrom(elementClass)) {
+            this.autoStartTransaction();
+            if (!this.rawGraph.index().getRelationshipAutoIndexer().isEnabled())
+                this.rawGraph.index().getRelationshipAutoIndexer().setEnabled(true);
+
+            this.rawGraph.index().getRelationshipAutoIndexer().startAutoIndexingProperty(key);
+            if (!this.getInternalIndexKeys(Edge.class).contains(key)) {
+                KeyIndexableGraphHelper.reIndexElements(this, this.getEdges(), new HashSet<String>(Arrays.asList(key)));
+                this.autoStartTransaction();
+                this.createInternalIndexKey(key, elementClass);
+            }
+        } else {
+            throw ExceptionFactory.classIsNotIndexable(elementClass);
+        }
+    }
+
+    public <T extends Element> Set<String> getIndexedKeys(final Class<T> elementClass) {
+        if (elementClass == null)
+            throw ExceptionFactory.classForElementCannotBeNull();
+
+        if (Vertex.class.isAssignableFrom(elementClass)) {
+            if (!this.rawGraph.index().getNodeAutoIndexer().isEnabled())
+                return Collections.emptySet();
+            return this.rawGraph.index().getNodeAutoIndexer().getAutoIndexedProperties();
+        } else if (Edge.class.isAssignableFrom(elementClass)) {
+            if (!this.rawGraph.index().getRelationshipAutoIndexer().isEnabled())
+                return Collections.emptySet();
+            return this.rawGraph.index().getRelationshipAutoIndexer().getAutoIndexedProperties();
+        } else {
+            throw ExceptionFactory.classIsNotIndexable(elementClass);
+        }
+    }
+
+    public void removeVertex(final Vertex vertex) {
+        this.autoStartTransaction();
+
+        try {
+            final Node node = ((Neo4jVertex) vertex).getRawVertex();
+            for (final Relationship relationship : node.getRelationships(org.neo4j.graphdb.Direction.BOTH)) {
+                relationship.delete();
+            }
+            node.delete();
+        } catch (NotFoundException nfe) {
+            throw ExceptionFactory.vertexWithIdDoesNotExist(vertex.getId());
+        } catch (IllegalStateException ise) {
+            // wrap the neo4j exception so that the message is consistent in blueprints.
+            throw ExceptionFactory.vertexWithIdDoesNotExist(vertex.getId());
+        }
+    }
+
+    public Neo4jEdge addEdge(final Object id, final Vertex outVertex, final Vertex inVertex, final String label) {
+        if (label == null)
+            throw ExceptionFactory.edgeLabelCanNotBeNull();
+
+        this.autoStartTransaction();
+        return new Neo4jEdge(((Neo4jVertex) outVertex).getRawVertex().createRelationshipTo(((Neo4jVertex) inVertex).getRawVertex(),
+                DynamicRelationshipType.withName(label)), this);
+    }
+
+    public Neo4jEdge getEdge(final Object id) {
+        if (null == id)
+            throw ExceptionFactory.edgeIdCanNotBeNull();
+
+        try {
+            final Long longId;
+            if (id instanceof Long)
+                longId = (Long) id;
+            else
+                longId = Double.valueOf(id.toString()).longValue();
+            return new Neo4jEdge(this.rawGraph.getRelationshipById(longId), this);
+        } catch (NotFoundException e) {
+            return null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public void removeEdge(final Edge edge) {
+        this.autoStartTransaction();
+        ((Relationship) ((Neo4jEdge) edge).getRawElement()).delete();
+    }
+
+    public void stopTransaction(Conclusion conclusion) {
+        if (Conclusion.SUCCESS == conclusion)
+            commit();
+        else
+            rollback();
+    }
+
+    public void commit() {
+        if (null == tx.get()) {
+            return;
+        }
+
+        try {
+            tx.get().success();
+        } finally {
+            tx.get().finish();
+            tx.remove();
+        }
+    }
+
+    public void rollback() {
+        if (null == tx.get()) {
+            return;
+        }
+
+        try {
+            javax.transaction.Transaction t = transactionManager.getTransaction();
+            if (t == null || t.getStatus() == Status.STATUS_ROLLEDBACK) {
+                return;
+            }
+            tx.get().failure();
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        } finally {
+            tx.get().close();
+            tx.remove();
+        }
+    }
+
+    public void shutdown() {
+        try {
+            this.commit();
+        } catch (TransactionFailureException e) {
+            logger.warning("Failure on shutdown "+e.getMessage());
+            // TODO: inspect why certain transactions fail
+        }
+        this.rawGraph.shutdown();
+    }
+
+    public void autoStartTransaction() {
+        if (tx.get() == null)
+            tx.set(this.rawGraph.beginTx());
+    }
+
+    public GraphDatabaseService getRawGraph() {
+        return this.rawGraph;
+    }
+
+    public Features getFeatures() {
+        return FEATURES;
+    }
+
+    public String toString() {
+        return StringFactory.graphString(this, this.rawGraph.toString());
+    }
+
+    public GraphQuery query() {
+        return new DefaultGraphQuery(this);
+    }
+
+    public Iterator<Map<String,Object>> query(String query, Map<String,Object> params) {
+        return cypher.execute(query,params==null ? Collections.<String,Object>emptyMap() : params).iterator();
+    }
+
+    public boolean nodeIsDeleted(long nodeId) {
+        return ((AbstractTransactionManager) transactionManager).getTransactionState().nodeIsDeleted(nodeId);
+    }
+    public boolean relationshipIsDeleted(long nodeId) {
+        return ((AbstractTransactionManager) transactionManager).getTransactionState().relationshipIsDeleted(nodeId);
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jHaGraph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jHaGraph.java
@@ -1,0 +1,45 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationConverter;
+import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
+import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A Blueprints implementation of the graph database Neo4j (http://neo4j.org) with High Availability mode.
+ *
+ * @author Stephen Mallette
+ */
+public class Neo4jHaGraph extends Neo4jGraph {
+
+    public Neo4jHaGraph(final String directory) {
+        super(new HighlyAvailableGraphDatabaseFactory().newHighlyAvailableDatabase(directory));
+    }
+
+    public Neo4jHaGraph(final String directory, final Map<String, String> configuration) {
+        super(new HighlyAvailableGraphDatabaseFactory().newHighlyAvailableDatabaseBuilder(directory).setConfig(configuration).newGraphDatabase());
+    }
+
+    public Neo4jHaGraph(final HighlyAvailableGraphDatabase rawGraph) {
+        super(rawGraph);
+    }
+
+    public Neo4jHaGraph(final Configuration configuration) {
+        this(configuration.getString("blueprints.neo4jha.directory", null),
+                convertConfiguration(configuration.subset("blueprints.neo4jha.conf")));
+    }
+
+    private static Map<String,String> convertConfiguration(final Configuration configuration) {
+        final Map<String,String> c = new HashMap<String,String>();
+        final Iterator<String> keys = configuration.getKeys();
+        while (keys.hasNext()) {
+            final String k = keys.next();
+            c.put(k, configuration.getString(k));
+        }
+        return c;
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jIndex.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jIndex.java
@@ -1,0 +1,149 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Index;
+import com.tinkerpop.blueprints.Parameter;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.StringFactory;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.index.IndexHits;
+import org.neo4j.graphdb.index.IndexManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jIndex<T extends Neo4jElement, S extends PropertyContainer> implements Index<T> {
+
+    private final Class<T> indexClass;
+    protected final Neo4jGraph graph;
+    private final String indexName;
+    protected org.neo4j.graphdb.index.Index<S> rawIndex;
+
+    protected Neo4jIndex(final String indexName, final Class<T> indexClass, final Neo4jGraph graph, final Parameter... indexParameters) {
+        this.indexClass = indexClass;
+        this.graph = graph;
+        this.indexName = indexName;
+        this.generateIndex(indexParameters);
+    }
+
+    public Class<T> getIndexClass() {
+        if (Vertex.class.isAssignableFrom(this.indexClass))
+            return (Class) Vertex.class;
+        else
+            return (Class) Edge.class;
+    }
+
+    public String getIndexName() {
+        return this.indexName;
+    }
+
+    public void put(final String key, final Object value, final T element) {
+        try {
+            this.graph.autoStartTransaction();
+            this.rawIndex.add((S) element.getRawElement(), key, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The underlying Neo4j graph does not natively support this method within a transaction.
+     * If the graph is not currently in a transaction, then the operation runs efficiently.
+     * If the graph is in a transaction, then, for every element, a try/catch is used to determine if its in the current transaction.
+     */
+    public CloseableIterable<T> get(final String key, final Object value) {
+        final IndexHits<S> itty = this.rawIndex.get(key, value);
+        if (this.indexClass.isAssignableFrom(Neo4jVertex.class))
+            return new Neo4jVertexIterable((Iterable<Node>) itty, this.graph, this.graph.checkElementsInTransaction());
+        else
+            return new Neo4jEdgeIterable((Iterable<Relationship>) itty, this.graph, this.graph.checkElementsInTransaction());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The underlying Neo4j graph does not natively support this method within a transaction.
+     * If the graph is not currently in a transaction, then the operation runs efficiently.
+     * If the graph is in a transaction, then, for every element, a try/catch is used to determine if its in the current transaction.
+     */
+    public CloseableIterable<T> query(final String key, final Object query) {
+        final IndexHits<S> itty = this.rawIndex.query(key, query);
+        if (this.indexClass.isAssignableFrom(Neo4jVertex.class))
+            return new Neo4jVertexIterable((Iterable<Node>) itty, this.graph, this.graph.checkElementsInTransaction());
+        else
+            return new Neo4jEdgeIterable((Iterable<Relationship>) itty, this.graph, this.graph.checkElementsInTransaction());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The underlying Neo4j graph does not natively support this method within a transaction.
+     * If the graph is not currently in a transaction, then the operation runs efficiently.
+     * If the graph is in a transaction, then, for every element, a try/catch is used to determine if its in the current transaction.
+     */
+    public long count(final String key, final Object value) {
+        if (!this.graph.checkElementsInTransaction()) {
+            final IndexHits hits = this.rawIndex.get(key, value);
+            final long count = hits.size();
+            hits.close();
+            return count;
+        } else {
+            final CloseableIterable<T> hits = this.get(key, value);
+            long count = 0;
+            for (final T t : hits) {
+                count++;
+            }
+            hits.close();
+            return count;
+        }
+    }
+
+    public void remove(final String key, final Object value, final T element) {
+        try {
+            this.graph.autoStartTransaction();
+            this.rawIndex.remove((S) element.getRawElement(), key, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private void generateIndex(final Parameter<Object, Object>... indexParameters) {
+        final IndexManager manager = this.graph.getRawGraph().index();
+        if (Vertex.class.isAssignableFrom(this.indexClass)) {
+            if (indexParameters.length > 0)
+                this.rawIndex = (org.neo4j.graphdb.index.Index<S>) manager.forNodes(this.indexName, generateParameterMap(indexParameters));
+            else
+                this.rawIndex = (org.neo4j.graphdb.index.Index<S>) manager.forNodes(this.indexName);
+        } else {
+            if (indexParameters.length > 0)
+                this.rawIndex = (org.neo4j.graphdb.index.Index<S>) manager.forRelationships(this.indexName, generateParameterMap(indexParameters));
+            else
+                this.rawIndex = (org.neo4j.graphdb.index.Index<S>) manager.forRelationships(this.indexName);
+        }
+    }
+
+    public String toString() {
+        return StringFactory.indexString(this);
+    }
+
+    private static Map<String, String> generateParameterMap(final Parameter<Object, Object>... indexParameters) {
+        final Map<String, String> map = new HashMap<String, String>();
+        for (final Parameter<Object, Object> parameter : indexParameters) {
+            map.put(parameter.getKey().toString(), parameter.getValue().toString());
+        }
+        return map;
+    }
+
+    public org.neo4j.graphdb.index.Index<S> getRawIndex() {
+        return this.rawIndex;
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jTokens.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jTokens.java
@@ -1,0 +1,9 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jTokens {
+    public static final String NODE_AUTO_INDEX = "node_auto_index";
+    public static final String RELATIONSHIP_AUTO_INDEX = "relationship_auto_index";
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jVertex.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jVertex.java
@@ -1,0 +1,160 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.VertexQuery;
+import com.tinkerpop.blueprints.util.DefaultVertexQuery;
+import com.tinkerpop.blueprints.util.MultiIterable;
+import com.tinkerpop.blueprints.util.StringFactory;
+import org.neo4j.graphdb.*;
+import org.neo4j.helpers.collection.IteratorWrapper;
+
+import java.util.*;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jVertex extends Neo4jElement implements Vertex {
+
+    public Neo4jVertex(final Node node, final Neo4jGraph graph) {
+        super(graph);
+        this.rawElement = node;
+
+    }
+
+    public Iterable<Edge> getEdges(final com.tinkerpop.blueprints.Direction direction, final String... labels) {
+        if (direction.equals(com.tinkerpop.blueprints.Direction.OUT))
+            return new Neo4jVertexEdgeIterable(this.graph, (Node) this.rawElement, Direction.OUTGOING, labels);
+        else if (direction.equals(com.tinkerpop.blueprints.Direction.IN))
+            return new Neo4jVertexEdgeIterable(this.graph, (Node) this.rawElement, Direction.INCOMING, labels);
+        else
+            return new MultiIterable(Arrays.asList(new Neo4jVertexEdgeIterable(this.graph, (Node) this.rawElement, Direction.OUTGOING, labels), new Neo4jVertexEdgeIterable(this.graph, (Node) this.rawElement, Direction.INCOMING, labels)));
+    }
+
+    public Iterable<Vertex> getVertices(final com.tinkerpop.blueprints.Direction direction, final String... labels) {
+        if (direction.equals(com.tinkerpop.blueprints.Direction.OUT))
+            return new Neo4jVertexVertexIterable(this.graph, (Node) this.rawElement, Direction.OUTGOING, labels);
+        else if (direction.equals(com.tinkerpop.blueprints.Direction.IN))
+            return new Neo4jVertexVertexIterable(this.graph, (Node) this.rawElement, Direction.INCOMING, labels);
+        else
+            return new MultiIterable(Arrays.asList(new Neo4jVertexVertexIterable(this.graph, (Node) this.rawElement, Direction.OUTGOING, labels), new Neo4jVertexVertexIterable(this.graph, (Node) this.rawElement, Direction.INCOMING, labels)));
+    }
+
+    public Edge addEdge(final String label, final Vertex vertex) {
+        return this.graph.addEdge(null, this, vertex, label);
+    }
+
+    public Collection<String> getLabels() {
+        Collection<String> labels=new ArrayList<String>();
+        for (Label label : getRawVertex().getLabels()) {
+            labels.add(label.name());
+        }
+        return labels;
+    }
+
+    public void addLabel(String label) {
+        graph.autoStartTransaction();
+        getRawVertex().addLabel(DynamicLabel.label(label));
+    }
+
+    public void removeLabel(String label) {
+        graph.autoStartTransaction();
+        getRawVertex().removeLabel(DynamicLabel.label(label));
+    }
+
+    public VertexQuery query() {
+        return new DefaultVertexQuery(this);
+    }
+
+    public boolean equals(final Object object) {
+        return object instanceof Neo4jVertex && ((Neo4jVertex) object).getId().equals(this.getId());
+    }
+
+    public String toString() {
+        return StringFactory.vertexString(this);
+    }
+
+    public Node getRawVertex() {
+        return (Node) this.rawElement;
+    }
+
+    private class Neo4jVertexVertexIterable<T extends Vertex> implements Iterable<Neo4jVertex> {
+        private final Neo4jGraph graph;
+        private final Node node;
+        private final Direction direction;
+        private final DynamicRelationshipType[] labels;
+
+        public Neo4jVertexVertexIterable(final Neo4jGraph graph, final Node node, final Direction direction, final String... labels) {
+            this.graph = graph;
+            this.node = node;
+            this.direction = direction;
+            this.labels = new DynamicRelationshipType[labels.length];
+            for (int i = 0; i < labels.length; i++) {
+                this.labels[i] = DynamicRelationshipType.withName(labels[i]);
+            }
+        }
+
+        public Iterator<Neo4jVertex> iterator() {
+            final Iterator<Relationship> itty;
+            if (labels.length > 0)
+                itty = node.getRelationships(direction, labels).iterator();
+            else
+                itty = node.getRelationships(direction).iterator();
+
+            return new Iterator<Neo4jVertex>() {
+                public Neo4jVertex next() {
+                    return new Neo4jVertex(itty.next().getOtherNode(node), graph);
+                }
+
+                public boolean hasNext() {
+                    return itty.hasNext();
+                }
+
+                public void remove() {
+                    itty.remove();
+                }
+            };
+        }
+    }
+
+    private class Neo4jVertexEdgeIterable<T extends Edge> implements Iterable<Neo4jEdge> {
+
+        private final Neo4jGraph graph;
+        private final Node node;
+        private final Direction direction;
+        private final DynamicRelationshipType[] labels;
+
+        public Neo4jVertexEdgeIterable(final Neo4jGraph graph, final Node node, final Direction direction, final String... labels) {
+            this.graph = graph;
+            this.node = node;
+            this.direction = direction;
+            this.labels = new DynamicRelationshipType[labels.length];
+            for (int i = 0; i < labels.length; i++) {
+                this.labels[i] = DynamicRelationshipType.withName(labels[i]);
+            }
+        }
+
+        public Iterator<Neo4jEdge> iterator() {
+            final Iterator<Relationship> itty;
+            if (labels.length > 0)
+                itty = node.getRelationships(direction, labels).iterator();
+            else
+                itty = node.getRelationships(direction).iterator();
+
+            return new Iterator<Neo4jEdge>() {
+                public Neo4jEdge next() {
+                    return new Neo4jEdge(itty.next(), graph);
+                }
+
+                public boolean hasNext() {
+                    return itty.hasNext();
+                }
+
+                public void remove() {
+                    itty.remove();
+                }
+            };
+        }
+    }
+
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jVertexIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jVertexIterable.java
@@ -1,0 +1,91 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Vertex;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.index.IndexHits;
+
+import java.util.Iterator;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jVertexIterable<T extends Vertex> implements CloseableIterable<Neo4jVertex> {
+
+    private final Iterable<Node> nodes;
+    private final Neo4jGraph graph;
+    private final boolean checkTransaction;
+    private static final String DUMMY_PROPERTY = "a";
+
+    public Neo4jVertexIterable(final Iterable<Node> nodes, final Neo4jGraph graph, final boolean checkTransaction) {
+        this.graph = graph;
+        this.nodes = nodes;
+        this.checkTransaction = checkTransaction;
+    }
+
+    public Neo4jVertexIterable(final Iterable<Node> nodes, final Neo4jGraph graph) {
+        this(nodes, graph, false);
+    }
+
+    public Iterator<Neo4jVertex> iterator() {
+        return new Iterator<Neo4jVertex>() {
+            private final Iterator<Node> itty = nodes.iterator();
+            private Node nextNode = null;
+
+            public void remove() {
+                this.itty.remove();
+            }
+
+            public Neo4jVertex next() {
+                if (!checkTransaction) {
+                    return new Neo4jVertex(this.itty.next(), graph);
+                } else {
+                    if (null != this.nextNode) {
+                        final Node temp = this.nextNode;
+                        this.nextNode = null;
+                        return new Neo4jVertex(temp, graph);
+                    } else {
+                        while (true) {
+                            final Node node = this.itty.next();
+                            try {
+                                if (!graph.nodeIsDeleted(node.getId())) return new Neo4jVertex(node, graph);
+                            } catch (final IllegalStateException e) {
+                                // tried to access a node not available to the transaction
+                            }
+                        }
+                    }
+                }
+            }
+
+            public boolean hasNext() {
+                if (!checkTransaction)
+                    return this.itty.hasNext();
+                else {
+                    if (null != this.nextNode)
+                        return true;
+                    else {
+                        while (this.itty.hasNext()) {
+                            final Node node = this.itty.next();
+                            try {
+                                if (!graph.nodeIsDeleted(node.getId())){
+                                    this.nextNode = node;
+                                    return true;
+                                }
+                            } catch (final IllegalStateException e) {
+                            }
+                        }
+                        return false;
+                    }
+                }
+            }
+        };
+    }
+
+    public void close() {
+        if (this.nodes instanceof IndexHits) {
+            ((IndexHits) this.nodes).close();
+        }
+    }
+
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchEdge.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchEdge.java
@@ -1,0 +1,63 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.ExceptionFactory;
+import com.tinkerpop.blueprints.util.StringFactory;
+
+import java.util.Map;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jBatchEdge extends Neo4jBatchElement implements Edge {
+
+    private final String label;
+
+    public Neo4jBatchEdge(final Neo4jBatchGraph graph, final Long id, final String label) {
+        super(graph, id);
+        this.label = label;
+    }
+
+    public <T> T removeProperty(final String key) {
+        final Map<String, Object> properties = this.getPropertyMapClone();
+        final Object value = properties.remove(key);
+        this.graph.getRawGraph().setRelationshipProperties(this.id, properties);
+        return (T) value;
+
+    }
+
+    public void setProperty(final String key, final Object value) {
+        if (key.isEmpty())
+            throw ExceptionFactory.propertyKeyCanNotBeEmpty();
+        if (key.equals(StringFactory.ID))
+            throw ExceptionFactory.propertyKeyIdIsReserved();
+        if (key.equals(StringFactory.LABEL))
+            throw ExceptionFactory.propertyKeyLabelIsReservedForEdges();
+
+        final Map<String, Object> properties = this.getPropertyMapClone();
+        properties.put(key, value);
+        this.graph.getRawGraph().setRelationshipProperties(this.id, properties);
+    }
+
+    public Map<String, Object> getPropertyMap() {
+        return this.graph.getRawGraph().getRelationshipProperties(this.id);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Vertex getVertex(final Direction direction) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public String toString() {
+        return "e[" + this.id + "][?-" + this.label + "->?]";
+    }
+
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchEdgeIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchEdgeIterable.java
@@ -1,0 +1,44 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Edge;
+import org.neo4j.graphdb.index.IndexHits;
+
+import java.util.Iterator;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jBatchEdgeIterable implements CloseableIterable<Edge> {
+
+    private final IndexHits<Long> hits;
+    private final Neo4jBatchGraph graph;
+
+    public Neo4jBatchEdgeIterable(final Neo4jBatchGraph graph, final IndexHits<Long> hits) {
+        this.hits = hits;
+        this.graph = graph;
+    }
+
+    public Iterator<Edge> iterator() {
+        return new Iterator<Edge>() {
+            private final Iterator<Long> itty = hits.iterator();
+
+            public void remove() {
+                itty.remove();
+            }
+
+            public boolean hasNext() {
+                return hits.hasNext();
+            }
+
+            public Edge next() {
+                return new Neo4jBatchEdge(graph, itty.next(), null);
+            }
+        };
+    }
+
+
+    public void close() {
+        hits.close();
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchElement.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchElement.java
@@ -1,0 +1,57 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.util.ElementHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+abstract class Neo4jBatchElement implements Element {
+
+    protected final Neo4jBatchGraph graph;
+    protected final Long id;
+
+    protected Neo4jBatchElement(final Neo4jBatchGraph graph, final Long id) {
+        this.graph = graph;
+        this.id = id;
+    }
+
+    public Object getId() {
+        return id;
+    }
+
+    public abstract Map<String, Object> getPropertyMap();
+
+    public Set<String> getPropertyKeys() {
+        return this.getPropertyMap().keySet();
+    }
+
+    public <T> T getProperty(final String key) {
+        return (T) this.getPropertyMap().get(key);
+    }
+
+    protected Map<String, Object> getPropertyMapClone() {
+        final Map<String, Object> clone = new HashMap<String, Object>();
+        for (Map.Entry<String, Object> entry : this.getPropertyMap().entrySet()) {
+            clone.put(entry.getKey(), entry.getValue());
+        }
+        return clone;
+
+    }
+
+    public int hashCode() {
+        return this.getId().hashCode();
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException(Neo4jBatchTokens.DELETE_OPERATION_MESSAGE);
+    }
+
+    public boolean equals(final Object object) {
+        return ElementHelper.areEqual(this, object);
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchGraph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchGraph.java
@@ -1,0 +1,420 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Features;
+import com.tinkerpop.blueprints.GraphQuery;
+import com.tinkerpop.blueprints.Index;
+import com.tinkerpop.blueprints.IndexableGraph;
+import com.tinkerpop.blueprints.KeyIndexableGraph;
+import com.tinkerpop.blueprints.MetaGraph;
+import com.tinkerpop.blueprints.Parameter;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.ExceptionFactory;
+import com.tinkerpop.blueprints.util.StringFactory;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.index.AutoIndexer;
+import org.neo4j.index.lucene.unsafe.batchinsert.LuceneBatchInserterIndexProvider;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.tooling.GlobalGraphOperations;
+import org.neo4j.unsafe.batchinsert.BatchInserter;
+import org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider;
+import org.neo4j.unsafe.batchinsert.BatchInserters;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Blueprints implementation of the Neo4j batch inserter for bulk loading data into a Neo4j graph.
+ * This is a single threaded, non-transactional bulk loader and should not be used for any other reason than for massive initial data loads.
+ * <p/>
+ * Neo4jBatchGraph is <b>not</b> a completely faithful Blueprints implementation.
+ * Many methods throw UnsupportedOperationExceptions and take unique arguments. Be sure to review each method's JavaDoc.
+ * The Neo4j "reference node" (vertex 0) is automatically created and is not removed until the database is shutdown() (do not add edges to the reference node).
+ * Key indices are not available until after the graph has been shutdown.
+ *
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jBatchGraph implements KeyIndexableGraph, IndexableGraph, MetaGraph<BatchInserter> {
+
+    private final BatchInserter rawGraph;
+    private final BatchInserterIndexProvider indexProvider;
+
+    private final Map<String, Neo4jBatchIndex<? extends Element>> indices = new HashMap<String, Neo4jBatchIndex<? extends Element>>();
+
+    private Long idCounter = 0l;
+
+    protected final Set<String> vertexIndexKeys = new HashSet<String>();
+    protected final Set<String> edgeIndexKeys = new HashSet<String>();
+
+    private static final Features FEATURES = new Features();
+
+    private static final String INDEXED_KEYS_POSTFIX = ":indexed_keys";
+
+    static {
+
+        FEATURES.supportsSerializableObjectProperty = false;
+        FEATURES.supportsBooleanProperty = true;
+        FEATURES.supportsDoubleProperty = true;
+        FEATURES.supportsFloatProperty = true;
+        FEATURES.supportsIntegerProperty = true;
+        FEATURES.supportsPrimitiveArrayProperty = true;
+        FEATURES.supportsUniformListProperty = true;
+        FEATURES.supportsMixedListProperty = false;
+        FEATURES.supportsLongProperty = true;
+        FEATURES.supportsMapProperty = false;
+        FEATURES.supportsStringProperty = true;
+
+        FEATURES.supportsDuplicateEdges = true;
+        FEATURES.supportsSelfLoops = true;
+        FEATURES.isPersistent = true;
+        FEATURES.isWrapper = false;
+        FEATURES.supportsVertexIteration = false;
+        FEATURES.supportsEdgeIteration = false;
+        FEATURES.supportsVertexIndex = true;
+        FEATURES.supportsEdgeIndex = true;
+        FEATURES.ignoresSuppliedIds = false;
+        FEATURES.supportsTransactions = false;
+        FEATURES.supportsIndices = true;
+        FEATURES.supportsKeyIndices = true;
+        FEATURES.supportsVertexKeyIndex = true;
+        FEATURES.supportsEdgeKeyIndex = true;
+        FEATURES.supportsEdgeRetrieval = true;
+        FEATURES.supportsVertexProperties = true;
+        FEATURES.supportsEdgeProperties = true;
+        FEATURES.supportsThreadedTransactions = false;
+    }
+
+
+    public Neo4jBatchGraph(final String directory) {
+        this.rawGraph = BatchInserters.inserter(directory);
+        this.indexProvider = new LuceneBatchInserterIndexProvider(this.rawGraph);
+    }
+
+    public Neo4jBatchGraph(final String directory, final Map<String, String> parameters) {
+        if (null == parameters)
+            this.rawGraph = BatchInserters.inserter(directory);
+        else
+            this.rawGraph = BatchInserters.inserter(directory, parameters);
+        this.indexProvider = new LuceneBatchInserterIndexProvider(this.rawGraph);
+    }
+
+    public Neo4jBatchGraph(final BatchInserter rawGraph, final BatchInserterIndexProvider indexProvider) {
+        this.rawGraph = rawGraph;
+        this.indexProvider = indexProvider;
+    }
+
+    public void shutdown() {
+        this.flushIndices();
+        this.indexProvider.shutdown();
+        this.rawGraph.shutdown();
+        removeReferenceNodeAndFinalizeKeyIndices();
+    }
+
+    /**
+     * This is necessary prior to using indices to ensure that indexed data is available to index queries.
+     * This method is not part of the Blueprints Graph or IndexableGraph API.
+     * Therefore, be sure to typecast your graph to a Neo4jBatchGraph to use this necessary index-based method.
+     * Note that key indices are not usable until the Neo4jBatchGraph has been shutdown.
+     */
+    public void flushIndices() {
+        for (final Neo4jBatchIndex index : this.indices.values()) {
+            index.flush();
+        }
+    }
+
+    private void removeReferenceNodeAndFinalizeKeyIndices() {
+        GraphDatabaseService rawGraphDB = null;
+        try {
+            GraphDatabaseBuilder builder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(this.rawGraph.getStoreDir());
+            if (this.vertexIndexKeys.size() > 0)
+                builder.setConfig(GraphDatabaseSettings.node_keys_indexable, vertexIndexKeys.toString().replace("[", "").replace("]", "")).setConfig(GraphDatabaseSettings.node_auto_indexing, "true");
+            if (this.edgeIndexKeys.size() > 0)
+                builder.setConfig(GraphDatabaseSettings.relationship_keys_indexable, edgeIndexKeys.toString().replace("[", "").replace("]", "")).setConfig(GraphDatabaseSettings.relationship_auto_indexing, "true");
+
+            rawGraphDB = builder.newGraphDatabase();
+
+            Transaction tx = rawGraphDB.beginTx();
+            try {
+                GlobalGraphOperations graphOperations = GlobalGraphOperations.at(rawGraphDB);
+                if (this.vertexIndexKeys.size() > 0)
+                    populateKeyIndices(rawGraphDB, rawGraphDB.index().getNodeAutoIndexer(), graphOperations.getAllNodes(), Vertex.class);
+                if (this.edgeIndexKeys.size() > 0)
+                    populateKeyIndices(rawGraphDB, rawGraphDB.index().getRelationshipAutoIndexer(), graphOperations.getAllRelationships(), Edge.class);
+                tx.success();
+            } finally {
+                tx.close();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        } finally {
+            if (rawGraphDB != null) rawGraphDB.shutdown();
+        }
+    }
+
+    private static <T extends PropertyContainer> void populateKeyIndices(final GraphDatabaseService rawGraphDB, final AutoIndexer<T> rawAutoIndexer, final Iterable<T> rawElements, final Class elementClass) {
+        if (!rawAutoIndexer.isEnabled())
+            return;
+
+
+        final Set<String> properties = rawAutoIndexer.getAutoIndexedProperties();
+        Transaction tx = rawGraphDB.beginTx();
+
+        final PropertyContainer kernel = ((GraphDatabaseAPI) rawGraphDB).getDependencyResolver().resolveDependency(NodeManager.class).getGraphProperties();
+        kernel.setProperty(elementClass.getSimpleName() + INDEXED_KEYS_POSTFIX, properties.toArray(new String[properties.size()]));
+
+        int count = 0;
+        for (final PropertyContainer pc : rawElements) {
+            for (final String property : properties) {
+                if (!pc.hasProperty(property)) continue;
+                pc.setProperty(property, pc.getProperty(property));
+                count++;
+                if (count >= 10000) {
+                    count = 0;
+                    tx.success();
+                    tx.finish();
+                    tx = rawGraphDB.beginTx();
+                }
+            }
+        }
+        tx.success();
+        tx.finish();
+    }
+
+    public String toString() {
+        return StringFactory.graphString(this, this.rawGraph.toString());
+    }
+
+    public BatchInserter getRawGraph() {
+        return this.rawGraph;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The object id can either be null, a long id, or a Map&lt;String,Object&gt;.
+     * If null, then an internal long is provided on the construction of the vertex.
+     * If a long id is provided, then the vertex is constructed with that long id.
+     * If a map is provided, then the map serves as the properties of the vertex.
+     * Moreover, if the map contains an _id key, then the value is a user provided long vertex id.
+     *
+     * @param id a id of properties which can be null
+     * @return the newly created vertex
+     */
+    public Vertex addVertex(final Object id) {
+
+        final Long finalId;
+        Map<String, Object> finalProperties = new HashMap<String, Object>();
+        if (null == id) {
+            rawGraph.createNode(++this.idCounter, finalProperties);
+            finalId = this.idCounter;
+        } else if (id instanceof Long) {
+            rawGraph.createNode((Long) id, finalProperties);
+            finalId = (Long) id;
+        } else if (id instanceof Map) {
+            finalProperties = makePropertyMap((Map<String, Object>) id);
+            final Long providedId = (Long) ((Map<String, Object>) id).get(Neo4jBatchTokens.ID);
+            finalProperties.remove(Neo4jBatchTokens.ID);
+            if (providedId == null)
+                finalId = rawGraph.createNode(finalProperties);
+            else {
+                rawGraph.createNode(providedId, finalProperties);
+                finalId = providedId;
+            }
+        } else {
+            try {
+                finalId = Double.valueOf(id.toString()).longValue();
+                rawGraph.createNode(finalId, finalProperties);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("The provided object must be null, a long id, an object convertible to long, or a Map<String,Object>");
+            }
+        }
+
+        return new Neo4jBatchVertex(this, finalId);
+    }
+
+    public Vertex getVertex(final Object id) {
+        if (null == id)
+            throw ExceptionFactory.vertexIdCanNotBeNull();
+
+        try {
+            final Long longId;
+            if (id instanceof Long)
+                longId = (Long) id;
+            else
+                longId = Double.valueOf(id.toString()).longValue();
+
+            if (rawGraph.nodeExists(longId)) {
+                return new Neo4jBatchVertex(this, longId);
+            } else {
+                return null;
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Iterable<Vertex> getVertices() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Iterable<Vertex> getVertices(final String key, final Object value) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public void removeVertex(final Vertex vertex) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException(Neo4jBatchTokens.DELETE_OPERATION_MESSAGE);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The object id must be a Map&lt;String,Object&gt; or null.
+     * The id is the properties written when the vertex is created.
+     * While it is possible to Edge.setProperty(), this method is faster.
+     *
+     * @param id a id of properties which can be null
+     * @return the newly created vertex
+     */
+    public Edge addEdge(final Object id, final Vertex outVertex, final Vertex inVertex, final String label) {
+        if (label == null)
+            throw ExceptionFactory.edgeLabelCanNotBeNull();
+
+        final Map<String, Object> finalProperties;
+        if (id == null || !(id instanceof Map))
+            finalProperties = new HashMap<String, Object>();
+        else
+            finalProperties = makePropertyMap((Map<String, Object>) id);
+        final Long finalId = this.rawGraph.createRelationship((Long) outVertex.getId(), (Long) inVertex.getId(), DynamicRelationshipType.withName(label), finalProperties);
+
+        return new Neo4jBatchEdge(this, finalId, label);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Edge getEdge(final Object id) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Iterable<Edge> getEdges() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Iterable<Edge> getEdges(final String key, final Object value) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public void removeEdge(final Edge edge) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException(Neo4jBatchTokens.DELETE_OPERATION_MESSAGE);
+    }
+
+    public <T extends Element> Index<T> getIndex(final String indexName, final Class<T> indexClass) {
+        return (Index<T>) this.indices.get(indexName);
+    }
+
+    public <T extends Element> Index<T> createIndex(final String indexName, final Class<T> indexClass, final Parameter... indexParameters) {
+        final Neo4jBatchIndex<T> index;
+
+        final Map<String, String> map = generateParameterMap(indexParameters);
+        if (indexParameters.length == 0) {
+            map.put(Neo4jBatchTokens.TYPE, Neo4jBatchTokens.EXACT);
+        }
+
+        if (Vertex.class.isAssignableFrom(indexClass)) {
+            index = new Neo4jBatchIndex<T>(this, indexProvider.nodeIndex(indexName, map), indexName, indexClass);
+        } else {
+            index = new Neo4jBatchIndex<T>(this, indexProvider.relationshipIndex(indexName, map), indexName, indexClass);
+        }
+        this.indices.put(indexName, index);
+        return index;
+    }
+
+    public Iterable<Index<? extends Element>> getIndices() {
+        return (Iterable) this.indices.values();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public void dropIndex(final String indexName) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException(Neo4jBatchTokens.DELETE_OPERATION_MESSAGE);
+    }
+
+    private Map<String, Object> makePropertyMap(final Map<String, Object> map) {
+        final Map<String, Object> properties = new HashMap<String, Object>();
+        for (final Map.Entry<String, Object> entry : map.entrySet()) {
+            if (!entry.getKey().equals(Neo4jBatchTokens.ID)) {
+                properties.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return properties;
+    }
+
+    public <T extends Element> void dropKeyIndex(final String key, final Class<T> elementClass) {
+        if (Vertex.class.isAssignableFrom(elementClass)) {
+            this.vertexIndexKeys.remove(key);
+        } else {
+            this.edgeIndexKeys.remove(key);
+        }
+    }
+
+    public <T extends Element> void createKeyIndex(final String key, final Class<T> elementClass, final Parameter... indexParameters) {
+        if (Vertex.class.isAssignableFrom(elementClass)) {
+            this.vertexIndexKeys.add(key);
+        } else {
+            this.edgeIndexKeys.add(key);
+        }
+    }
+
+    public <T extends Element> Set<String> getIndexedKeys(final Class<T> elementClass) {
+        if (Vertex.class.isAssignableFrom(elementClass)) {
+            return this.vertexIndexKeys;
+        } else {
+            return this.edgeIndexKeys;
+        }
+    }
+
+    private static Map<String, String> generateParameterMap(final Parameter<Object, Object>... indexParameters) {
+        final Map<String, String> map = new HashMap<String, String>();
+        for (final Parameter<Object, Object> parameter : indexParameters) {
+            map.put(parameter.getKey().toString(), parameter.getValue().toString());
+        }
+        return map;
+    }
+
+    public Features getFeatures() {
+        return FEATURES;
+    }
+
+    public GraphQuery query() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchIndex.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchIndex.java
@@ -1,0 +1,84 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Index;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.StringFactory;
+import org.neo4j.unsafe.batchinsert.BatchInserterIndex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jBatchIndex<T extends Element> implements Index<T> {
+
+    private final Neo4jBatchGraph graph;
+    protected final BatchInserterIndex rawIndex;
+    private final String name;
+    private final Class<T> indexClass;
+
+    public Neo4jBatchIndex(final Neo4jBatchGraph graph, final BatchInserterIndex index, final String name, final Class<T> indexClass) {
+        this.graph = graph;
+        this.rawIndex = index;
+        this.name = name;
+        this.indexClass = indexClass;
+    }
+
+    public void put(final String key, final Object value, final T element) {
+        final Map<String, Object> map = new HashMap<String, Object>();
+        map.put(key, value);
+        this.rawIndex.add((Long) element.getId(), map);
+    }
+
+    public CloseableIterable<T> get(final String key, final Object value) {
+        if (Vertex.class.isAssignableFrom(this.indexClass))
+            return (CloseableIterable<T>) new Neo4jBatchVertexIterable(this.graph, this.rawIndex.get(key, value));
+        else
+            return (CloseableIterable<T>) new Neo4jBatchEdgeIterable(this.graph, this.rawIndex.get(key, value));
+    }
+
+    public CloseableIterable<T> query(final String key, final Object query) {
+        if (Vertex.class.isAssignableFrom(this.indexClass))
+            return (CloseableIterable<T>) new Neo4jBatchVertexIterable(this.graph, this.rawIndex.query(key, query));
+        else
+            return (CloseableIterable<T>) new Neo4jBatchEdgeIterable(this.graph, this.rawIndex.query(key, query));
+    }
+
+    public long count(final String key, final Object value) {
+        long count = 0;
+        for (final T t : this.get(key, value)) {
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public void remove(final String key, final Object value, final T element) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException(Neo4jBatchTokens.DELETE_OPERATION_MESSAGE);
+    }
+
+    public Class<T> getIndexClass() {
+        return this.indexClass;
+    }
+
+    public String getIndexName() {
+        return this.name;
+    }
+
+    /**
+     * This is required before querying the index for data.
+     * This method is not a standard Index API method and thus, be sure to typecast the index to Neo4jBatchIndex.
+     */
+    public void flush() {
+        this.rawIndex.flush();
+    }
+
+    public String toString() {
+        return StringFactory.indexString(this);
+    }
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchTokens.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchTokens.java
@@ -1,0 +1,12 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jBatchTokens {
+
+    public static final String TYPE = "type";
+    public static final String EXACT = "exact";
+    public static final String ID = "_id";
+    public static final String DELETE_OPERATION_MESSAGE = "Delete operations are not supported";
+}

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchVertex.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchVertex.java
@@ -1,0 +1,73 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.VertexQuery;
+import com.tinkerpop.blueprints.util.ExceptionFactory;
+import com.tinkerpop.blueprints.util.StringFactory;
+
+import java.util.Map;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jBatchVertex extends Neo4jBatchElement implements Vertex {
+
+    public Neo4jBatchVertex(final Neo4jBatchGraph graph, final Long id) {
+        super(graph, id);
+    }
+
+    public <T> T removeProperty(final String key) {
+        final Map<String, Object> properties = this.getPropertyMapClone();
+        final Object value = properties.remove(key);
+        this.graph.getRawGraph().setNodeProperties(this.id, properties);
+        return (T) value;
+
+    }
+
+    public void setProperty(final String key, final Object value) {
+        if (key.isEmpty())
+            throw ExceptionFactory.propertyKeyCanNotBeEmpty();
+        if (key.equals(StringFactory.ID))
+            throw ExceptionFactory.propertyKeyIdIsReserved();
+
+        final Map<String, Object> properties = this.getPropertyMapClone();
+        properties.put(key, value);
+        this.graph.getRawGraph().setNodeProperties(this.id, properties);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Iterable<Edge> getEdges(final Direction direction, final String... labels) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public Iterable<Vertex> getVertices(final Direction direction, final String... labels) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Edge addEdge(final String label, final Vertex vertex) {
+        return this.graph.addEdge(null, this, vertex, label);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public VertexQuery query() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Map<String, Object> getPropertyMap() {
+        return this.graph.getRawGraph().getNodeProperties(this.id);
+    }
+
+    public String toString() {
+        return StringFactory.vertexString(this);
+    }
+}
+

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchVertexIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchVertexIterable.java
@@ -1,0 +1,44 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Vertex;
+import org.neo4j.graphdb.index.IndexHits;
+
+import java.util.Iterator;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class Neo4jBatchVertexIterable implements CloseableIterable<Vertex> {
+
+    private final IndexHits<Long> hits;
+    private final Neo4jBatchGraph graph;
+
+    public Neo4jBatchVertexIterable(final Neo4jBatchGraph graph, final IndexHits<Long> hits) {
+        this.hits = hits;
+        this.graph = graph;
+    }
+
+    public Iterator<Vertex> iterator() {
+        return new Iterator<Vertex>() {
+            private final Iterator<Long> itty = hits.iterator();
+
+            public void remove() {
+                itty.remove();
+            }
+
+            public boolean hasNext() {
+                return hits.hasNext();
+            }
+
+            public Vertex next() {
+                return new Neo4jBatchVertex(graph, itty.next());
+            }
+        };
+    }
+
+
+    public void close() {
+        hits.close();
+    }
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jBenchmarkTestSuite.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jBenchmarkTestSuite.java
@@ -1,0 +1,103 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.BaseTest;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.TestSuite;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.impls.GraphTest;
+import com.tinkerpop.blueprints.util.io.graphml.GraphMLReader;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jBenchmarkTestSuite extends TestSuite {
+
+    private static final int TOTAL_RUNS = 10;
+
+    public Neo4jBenchmarkTestSuite() {
+    }
+
+    public Neo4jBenchmarkTestSuite(final GraphTest graphTest) {
+        super(graphTest);
+    }
+
+    public void testNeo4jRaw() throws Exception {
+        double totalTime = 0.0d;
+        Graph graph = graphTest.generateGraph();
+        GraphMLReader.inputGraph(graph, GraphMLReader.class.getResourceAsStream("graph-example-2.xml"));
+        graph.shutdown();
+
+        for (int i = 0; i < TOTAL_RUNS; i++) {
+            graph = graphTest.generateGraph();
+            GraphDatabaseService neo4j = ((Neo4jGraph) graph).getRawGraph();
+            int counter = 0;
+            this.stopWatch();
+            for (final Node node : neo4j.getAllNodes()) {
+                counter++;
+                for (final Relationship relationship : node.getRelationships(Direction.OUTGOING)) {
+                    counter++;
+                    final Node node2 = relationship.getEndNode();
+                    counter++;
+                    for (final Relationship relationship2 : node2.getRelationships(Direction.OUTGOING)) {
+                        counter++;
+                        final Node node3 = relationship2.getEndNode();
+                        counter++;
+                        for (final Relationship relationship3 : node3.getRelationships(Direction.OUTGOING)) {
+                            counter++;
+                            relationship3.getEndNode();
+                            counter++;
+                        }
+                    }
+                }
+            }
+            double currentTime = this.stopWatch();
+            totalTime = totalTime + currentTime;
+            BaseTest.printPerformance(neo4j.toString(), counter, "Neo4j raw elements touched", currentTime);
+            graph.shutdown();
+        }
+        BaseTest.printPerformance("Neo4jRaw", 1, "Neo4j Raw experiment average", totalTime / (double) TOTAL_RUNS);
+    }
+
+    public void testNeo4jGraph() throws Exception {
+        double totalTime = 0.0d;
+        Graph graph = graphTest.generateGraph();
+        GraphMLReader.inputGraph(graph, GraphMLReader.class.getResourceAsStream("graph-example-2.xml"));
+        graph.shutdown();
+
+        for (int i = 0; i < TOTAL_RUNS; i++) {
+            graph = graphTest.generateGraph();
+            this.stopWatch();
+            int counter = 0;
+            for (final Vertex vertex : graph.getVertices()) {
+                counter++;
+                for (final Edge edge : vertex.getEdges(com.tinkerpop.blueprints.Direction.OUT)) {
+                    counter++;
+                    final Vertex vertex2 = edge.getVertex(com.tinkerpop.blueprints.Direction.IN);
+                    counter++;
+                    for (final Edge edge2 : vertex2.getEdges(com.tinkerpop.blueprints.Direction.OUT)) {
+                        counter++;
+                        final Vertex vertex3 = edge2.getVertex(com.tinkerpop.blueprints.Direction.IN);
+                        counter++;
+                        for (final Edge edge3 : vertex3.getEdges(com.tinkerpop.blueprints.Direction.OUT)) {
+                            counter++;
+                            edge3.getVertex(com.tinkerpop.blueprints.Direction.OUT);
+                            counter++;
+                        }
+                    }
+                }
+            }
+            double currentTime = this.stopWatch();
+            totalTime = totalTime + currentTime;
+            BaseTest.printPerformance(graph.toString(), counter, "Neo4jGraph elements touched", currentTime);
+            graph.shutdown();
+        }
+        BaseTest.printPerformance("Neo4jGraph", 1, "Neo4jGraph experiment average", totalTime / (double) TOTAL_RUNS);
+    }
+
+
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphCypherTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphCypherTest.java
@@ -1,0 +1,54 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.impl.util.FileUtils;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mh
+ * @since 08.01.14
+ */
+public class Neo4jGraphCypherTest {
+    private Neo4jGraph graph;
+
+    @Before
+    public void setUp() throws Exception {
+        FileUtils.deleteRecursively(new File("target/test.db"));
+        graph = new Neo4jGraph("target/test.db");
+    }
+
+    @Test
+    public void testVertexLabels() throws Exception {
+        Neo4jVertex vertex = graph.addVertex(null);
+        vertex.addLabel("Label");
+        vertex.setProperty("key","value");
+        queryAndAssert(vertex);
+
+        graph.commit();
+
+        graph.query("create index on :Label(key)",null);
+
+        queryAndAssert(vertex);
+    }
+
+    private void queryAndAssert(Neo4jVertex vertex) {
+        Map<String, Object> params = MapUtil.map("prop", "value");
+        Map<String,Object> row = IteratorUtil.single(graph.query("MATCH (n:Label {key:{prop}}) RETURN n", params));
+        assertEquals(vertex.getRawVertex(), row.get("n"));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        graph.shutdown();
+    }
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphSpecificTestSuite.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphSpecificTestSuite.java
@@ -1,0 +1,171 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Index;
+import com.tinkerpop.blueprints.Parameter;
+import com.tinkerpop.blueprints.TestSuite;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.impls.GraphTest;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.event.TransactionData;
+import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.index.impl.lucene.LowerCaseKeywordAnalyzer;
+import org.neo4j.kernel.InternalAbstractGraphDatabase;
+import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import java.util.Iterator;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jGraphSpecificTestSuite extends TestSuite {
+
+    public Neo4jGraphSpecificTestSuite() {
+    }
+
+    public Neo4jGraphSpecificTestSuite(final GraphTest graphTest) {
+        super(graphTest);
+    }
+
+    public void testLongIdConversions() {
+        String id1 = "100";  // good  100
+        String id2 = "100.0"; // good 100
+        String id3 = "100.1"; // good 100
+        String id4 = "one"; // bad
+
+        try {
+            Double.valueOf(id1).longValue();
+            assertTrue(true);
+        } catch (NumberFormatException e) {
+            assertFalse(true);
+        }
+        try {
+            Double.valueOf(id2).longValue();
+            assertTrue(true);
+        } catch (NumberFormatException e) {
+            assertFalse(true);
+        }
+        try {
+            Double.valueOf(id3).longValue();
+            assertTrue(true);
+        } catch (NumberFormatException e) {
+            assertFalse(true);
+        }
+        try {
+            Double.valueOf(id4).longValue();
+            assertTrue(false);
+        } catch (NumberFormatException e) {
+            assertFalse(false);
+        }
+    }
+
+    public void testQueryIndex() throws Exception {
+        Neo4jGraph graph = (Neo4jGraph) graphTest.generateGraph();
+        Index<Vertex> vertexIndex = graph.createIndex("vertices", Vertex.class);
+        Index<Edge> edgeIndex = graph.createIndex("edges", Edge.class);
+
+        Vertex a = graph.addVertex(null);
+        a.setProperty("name", "marko");
+        vertexIndex.put("name", "marko", a);
+
+        Iterator itty = graph.getIndex("vertices", Vertex.class).query("name", "*rko").iterator();
+        int counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next(), a);
+        }
+        assertEquals(counter, 1);
+
+        Vertex b = graph.addVertex(null);
+        Edge edge = graph.addEdge(null, a, b, "knows");
+        edge.setProperty("weight", 0.75);
+        edgeIndex.put("weight", 0.75, edge);
+
+        itty = graph.getIndex("edges", Edge.class).query("label", "k?ows").iterator();
+        counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next(), edge);
+        }
+        assertEquals(counter, 0);
+
+        itty = graph.getIndex("edges", Edge.class).query("weight", "[0.5 TO 1.0]").iterator();
+        counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next(), edge);
+        }
+        assertEquals(counter, 1);
+        assertEquals(count(graph.getIndex("edges", Edge.class).query("weight", "[0.1 TO 0.5]")), 0);
+
+
+        graph.shutdown();
+    }
+
+    public void testIndexParameters() throws Exception {
+        Neo4jGraph graph = (Neo4jGraph) graphTest.generateGraph();
+        Index<Vertex> index = graph.createIndex("luceneIdx", Vertex.class, new Parameter<String, String>("analyzer", LowerCaseKeywordAnalyzer.class.getName()));
+        Vertex a = graph.addVertex(null);
+        a.setProperty("name", "marko");
+        index.put("name", "marko", a);
+        Iterator itty = index.query("name", "*rko").iterator();
+        int counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next(), a);
+        }
+        assertEquals(counter, 1);
+
+        itty = index.query("name", "MaRkO").iterator();
+        counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next(), a);
+        }
+        assertEquals(counter, 1);
+
+        graph.shutdown();
+    }
+
+    public void testHaGraph() throws Exception {
+        assertTrue(InternalAbstractGraphDatabase.class.isAssignableFrom(HighlyAvailableGraphDatabase.class));
+
+        /*String directory = this.getWorkingDirectory();
+        Neo4jHaGraph graph = new Neo4jHaGraph(directory);
+        graph.shutdown();
+        deleteDirectory(new File(directory));*/
+    }
+
+    public void testRollbackExceptionOnBeforeTxCommit() throws Exception {
+        Neo4jGraph graph = (Neo4jGraph) graphTest.generateGraph();
+        GraphDatabaseService rawGraph = graph.getRawGraph();
+        rawGraph.registerTransactionEventHandler(new TransactionEventHandler<Object>() {
+            @Override
+            public Object beforeCommit(TransactionData data) throws Exception {
+                if (true) {
+                    throw new RuntimeException("jippo validation exception");
+                }
+                return null;  //To change body of implemented methods use File | Settings | File Templates.
+            }
+
+            @Override
+            public void afterCommit(TransactionData data, Object state) {
+                //To change body of implemented methods use File | Settings | File Templates.
+            }
+
+            @Override
+            public void afterRollback(TransactionData data, Object state) {
+                //To change body of implemented methods use File | Settings | File Templates.
+            }
+        });
+        try {
+            Vertex vertex = graph.addVertex(null);
+            graph.commit();
+        } catch (Exception e) {
+            graph.rollback();
+        }
+        assertTrue(!GlobalGraphOperations.at(rawGraph).getAllNodes().iterator().hasNext());
+        graph.shutdown();
+    }
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphTest.java
@@ -1,0 +1,251 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.EdgeTestSuite;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.GraphQueryTestSuite;
+import com.tinkerpop.blueprints.GraphTestSuite;
+import com.tinkerpop.blueprints.IndexTestSuite;
+import com.tinkerpop.blueprints.IndexableGraphTestSuite;
+import com.tinkerpop.blueprints.KeyIndexableGraphTestSuite;
+import com.tinkerpop.blueprints.TestSuite;
+import com.tinkerpop.blueprints.TransactionalGraphTestSuite;
+import com.tinkerpop.blueprints.VertexQueryTestSuite;
+import com.tinkerpop.blueprints.VertexTestSuite;
+import com.tinkerpop.blueprints.impls.GraphTest;
+import com.tinkerpop.blueprints.util.io.gml.GMLReaderTestSuite;
+import com.tinkerpop.blueprints.util.io.graphml.GraphMLReaderTestSuite;
+import com.tinkerpop.blueprints.util.io.graphson.GraphSONReaderTestSuite;
+import org.neo4j.graphdb.Transaction;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.*;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jGraphTest extends GraphTest {
+
+    /*public void testNeo4jBenchmarkTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new Neo4jBenchmarkTestSuite(this));
+        printTestPerformance("Neo4jBenchmarkTestSuite", this.stopWatch());
+    }*/
+
+    public void testVertexTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new VertexTestSuite(this));
+        printTestPerformance("VertexTestSuite", this.stopWatch());
+    }
+
+    public void testEdgeTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new EdgeTestSuite(this));
+        printTestPerformance("EdgeTestSuite", this.stopWatch());
+    }
+
+    public void testGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphTestSuite(this));
+        printTestPerformance("GraphTestSuite", this.stopWatch());
+    }
+
+    public void testVertexQueryTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new VertexQueryTestSuite(this));
+        printTestPerformance("VertexQueryTestSuite", this.stopWatch());
+    }
+
+    public void testGraphQueryTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphQueryTestSuite(this));
+        printTestPerformance("GraphQueryTestSuite", this.stopWatch());
+    }
+
+    public void testKeyIndexableGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new KeyIndexableGraphTestSuite(this));
+        printTestPerformance("KeyIndexableGraphTestSuite", this.stopWatch());
+    }
+
+    public void testIndexableGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new IndexableGraphTestSuite(this));
+        printTestPerformance("IndexableGraphTestSuite", this.stopWatch());
+    }
+
+    public void testIndexTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new IndexTestSuite(this));
+        printTestPerformance("IndexTestSuite", this.stopWatch());
+    }
+
+    public void testTransactionalGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new TransactionalGraphTestSuite(this));
+        printTestPerformance("TransactionalGraphTestSuite", this.stopWatch());
+    }
+
+    public void testGraphMLReaderTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphMLReaderTestSuite(this));
+        printTestPerformance("GraphMLReaderTestSuite", this.stopWatch());
+    }
+
+    public void testGraphSONReaderTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphSONReaderTestSuite(this));
+        printTestPerformance("GraphSONReaderTestSuite", this.stopWatch());
+    }
+
+    public void testGMLReaderTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GMLReaderTestSuite(this));
+        printTestPerformance("GMLReaderTestSuite", this.stopWatch());
+    }
+
+    public void testNeo4jGraphSpecificTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new Neo4jGraphSpecificTestSuite(this));
+        printTestPerformance("Neo4jGraphSpecificTestSuite", this.stopWatch());
+    }
+
+    public Graph generateGraph() {
+        return generateGraph("graph");
+    }
+
+    public Graph generateGraph(final String graphDirectoryName) {
+        final String directory = getWorkingDirectory();
+        Neo4jGraph graph = new Neo4jTestGraph(directory + "/" + graphDirectoryName);
+        graph.setCheckElementsInTransaction(true);
+
+        // for clean shutdown later
+        testGraph.set(graph);
+
+        return graph;
+    }
+
+    private final static ThreadLocal<Graph> testGraph = new ThreadLocal<Graph>();
+
+    public void doTestSuite(final TestSuite testSuite) throws Exception {
+        String directory = this.getWorkingDirectory();
+        deleteDirectory(new File(directory));
+        int total=0;
+        Map<Method,Exception> failures=new LinkedHashMap<Method,Exception>();
+        for (Method method : testSuite.getClass().getDeclaredMethods()) {
+            if (method.getName().startsWith("test")) {
+                System.out.println("Testing " + method.getName() + "...");
+                try {
+                    total++;
+                    method.invoke(testSuite);
+                } catch(Exception e) {
+                    // report all errors not just the first
+                    failures.put(method,e);
+                    System.out.println("Error during "+method.getName()+" "+e.getMessage());
+                    e.printStackTrace();
+                } finally {
+                    // clean shutdown w/o leaking resources even in case of AssertionErrors
+                    if (testGraph.get()!=null) {
+                        testGraph.get().shutdown();
+                    }
+                    deleteDirectory(new File(directory));
+                }
+            }
+        }
+        // fail the suite
+        if (!failures.isEmpty()) {
+            throw new AssertionError(testSuite.getName()+" failed, total "+ total+ " failures: "+failures.size()+"\n"+
+            failures.keySet());
+        }
+    }
+
+    private String getWorkingDirectory() {
+        return this.computeTestDataRoot().getAbsolutePath();
+    }
+
+    private static class Neo4jTestGraph extends Neo4jGraph {
+        private final static ThreadLocal<Transaction> outerTx = new ThreadLocal<Transaction>();
+        private Collection<Transaction> outerTransactions;
+        boolean shuttingDown = false;
+
+        public Neo4jTestGraph(String path) {
+            super(path);
+        }
+
+        @Override
+        protected void init() {
+            outerTransactions = new HashSet<Transaction>();
+            restartTx();
+            super.init();
+        }
+
+        private void restartTx() {
+            Transaction tx = getRawGraph().beginTx();
+            outerTx.set(tx);
+            outerTransactions.add(tx);
+        }
+
+        @Override
+        public void shutdown() {
+            shuttingDown = true;
+            finishOuter(true,false);
+            closeOpenTransactions();
+            super.shutdown();
+            testGraph.remove();
+        }
+
+        private void closeOpenTransactions() {
+            Iterator<Transaction> it = outerTransactions.iterator();
+            while (it.hasNext()) {
+                Transaction tx = it.next();
+                try {
+                    tx.failure();
+                } catch(Exception e) {
+//                    System.out.println("Error cleaning up outer transaction " + e.getMessage());
+                } finally {
+                    try {
+                        tx.close();
+                    } catch(Exception e) {
+//                        System.out.println("Error cleaning up outer transaction " + e.getMessage());
+                    }
+                }
+                it.remove();
+            }
+        }
+
+        private void finishOuter(boolean success, boolean restart) {
+            if (outerTx.get() != null) {
+                Transaction tx = outerTx.get();
+                try {
+                    if (success) tx.success();
+                    else tx.failure();
+                } catch (Exception e) {
+//                    System.out.println("Error " + (success ? "succeeding" : "failing") + " outer transaction " + e.getMessage());
+                } finally {
+                    try {
+                        tx.close();
+                    } catch (Exception e) {
+//                        System.out.println("Error committing " + (success ? "successful" : "failing") + " outer transaction " + e.getMessage());
+                    }
+                    outerTransactions.remove(tx);
+                    outerTx.remove();
+                }
+            }
+            if (restart && !shuttingDown) {
+                restartTx();
+            }
+        }
+
+        @Override
+        public void commit() {
+            super.commit();
+            finishOuter(true,true);
+        }
+
+        @Override
+        public void rollback() {
+            super.rollback();
+            finishOuter(false,true);
+        }
+    }
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphUsingANonInternalAbstractGraphClassFail.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jGraphUsingANonInternalAbstractGraphClassFail.java
@@ -1,0 +1,234 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import com.tinkerpop.blueprints.Vertex;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNull;
+import org.junit.Test;
+import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.event.KernelEventHandler;
+import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.graphdb.schema.Schema;
+import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
+import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.TransactionBuilder;
+import org.neo4j.kernel.impl.nioneo.store.StoreId;
+
+import static org.junit.Assert.assertThat;
+
+public class Neo4jGraphUsingANonInternalAbstractGraphClassFail {
+    private class LazyLoadedGraphDatabase implements GraphDatabaseService {
+        private GraphDatabaseService lazy;
+
+        public GraphDatabaseService getLazy() {
+            if (lazy == null) {
+                // load that lazy graph in a unique folder
+                lazy = new GraphDatabaseFactory().newEmbeddedDatabase(getClass().getName() + "/" + System.currentTimeMillis());
+            }
+            return lazy;
+        }
+
+        /**
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#createNode()
+         */
+        public Node createNode() {
+            return getLazy().createNode();
+        }
+
+        /**
+         * @param id
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#getNodeById(long)
+         */
+        public Node getNodeById(long id) {
+            return getLazy().getNodeById(id);
+        }
+
+        /**
+         * @param id
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#getRelationshipById(long)
+         */
+        public Relationship getRelationshipById(long id) {
+            return getLazy().getRelationshipById(id);
+        }
+
+        /**
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#getAllNodes()
+         * @deprecated
+         */
+        public Iterable<Node> getAllNodes() {
+            return getLazy().getAllNodes();
+        }
+
+        /**
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#getRelationshipTypes()
+         * @deprecated
+         */
+        public Iterable<RelationshipType> getRelationshipTypes() {
+            return getLazy().getRelationshipTypes();
+        }
+
+        /**
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#shutdown()
+         */
+        public void shutdown() {
+            getLazy().shutdown();
+        }
+
+        /**
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#beginTx()
+         */
+        public Transaction beginTx() {
+            return getLazy().beginTx();
+        }
+
+        /**
+         * @param handler
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#registerTransactionEventHandler(org.neo4j.graphdb.event.TransactionEventHandler)
+         */
+        public <T> TransactionEventHandler<T> registerTransactionEventHandler(TransactionEventHandler<T> handler) {
+            return getLazy().registerTransactionEventHandler(handler);
+        }
+
+        /**
+         * @param handler
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#unregisterTransactionEventHandler(org.neo4j.graphdb.event.TransactionEventHandler)
+         */
+        public <T> TransactionEventHandler<T> unregisterTransactionEventHandler(TransactionEventHandler<T> handler) {
+            return getLazy().unregisterTransactionEventHandler(handler);
+        }
+
+        /**
+         * @param handler
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#registerKernelEventHandler(org.neo4j.graphdb.event.KernelEventHandler)
+         */
+        public KernelEventHandler registerKernelEventHandler(KernelEventHandler handler) {
+            return getLazy().registerKernelEventHandler(handler);
+        }
+
+        /**
+         * @param handler
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#unregisterKernelEventHandler(org.neo4j.graphdb.event.KernelEventHandler)
+         */
+        public KernelEventHandler unregisterKernelEventHandler(KernelEventHandler handler) {
+            return getLazy().unregisterKernelEventHandler(handler);
+        }
+
+        /**
+         * @return
+         * @category delegate
+         * @see org.neo4j.graphdb.GraphDatabaseService#index()
+         */
+        public IndexManager index() {
+            return getLazy().index();
+        }
+
+        @Override
+        public Node createNode(Label... labels) {
+            return getLazy().createNode(labels);
+        }
+
+        @Override
+        public ResourceIterable<Node> findNodesByLabelAndProperty(Label label, String key, Object value) {
+            return getLazy().findNodesByLabelAndProperty(label,key,value);
+        }
+
+        @Override
+        public boolean isAvailable(long timeout) {
+            return getLazy().isAvailable(timeout);
+        }
+
+        @Override
+        public Schema schema() {
+            return getLazy().schema();
+        }
+
+        @Override
+        public TraversalDescription traversalDescription() {
+            return getLazy().traversalDescription();
+        }
+
+        @Override
+        public BidirectionalTraversalDescription bidirectionalTraversalDescription() {
+            return getLazy().bidirectionalTraversalDescription();
+        }
+    }
+
+    private class LazyLoadableGraphAPI extends LazyLoadedGraphDatabase implements GraphDatabaseAPI {
+
+        @Override
+        public DependencyResolver getDependencyResolver() {
+            return ((GraphDatabaseAPI) getLazy()).getDependencyResolver();
+        }
+
+        @Override
+        @Deprecated
+        public String getStoreDir() {
+            return ((GraphDatabaseAPI) getLazy()).getStoreDir();
+        }
+
+        @Override
+        @Deprecated
+        public StoreId storeId() {
+            return ((GraphDatabaseAPI) getLazy()).storeId();
+        }
+
+        @Override
+        @Deprecated
+        public TransactionBuilder tx() {
+            return ((GraphDatabaseAPI) getLazy()).tx();
+        }
+
+    }
+
+    /**
+     * in this test, our class is a graph database service, but not an InternalAbstractGraphDatabase instance.As a consequence, {@link Neo4jGraph#getInternalIndexKeys}
+     * won't load any index, with an additional {@link ClassCastException}
+     */
+    @Test
+    public void loadingANeo4jGraphFromAnyGraphDatabaseClassShouldWork() throws ClassCastException {
+        Neo4jGraph tested = new Neo4jGraph(new LazyLoadedGraphDatabase());
+        assertThat(tested, IsNull.notNullValue());
+        // this one isn't a GraphDatabaseAPI. As a consequence, the indexing features are disgraded.
+        assertThat(tested.getIndices().iterator().hasNext(), Is.is(false));
+    }
+
+    /**
+     * in this test, our class is a graph database service, but not an InternalAbstractGraphDatabase instance.As a consequence, {@link Neo4jGraph#getInternalIndexKeys}
+     * won't load any index, with an additional {@link ClassCastException}
+     */
+    @Test
+    public void loadingANeo4jGraphFromAnyGraphAPIClassShouldWork() throws ClassCastException {
+        String METHOD_NAME = "#loadingANeo4jGraphFromAnyGraphAPIClassShouldWork";
+        Neo4jGraph tested = new Neo4jGraph(new LazyLoadableGraphAPI());
+        assertThat(tested, IsNull.notNullValue());
+        // at startup there is no index
+        assertThat(tested.getIndices().iterator().hasNext(), Is.is(false));
+        // now create an index
+        tested.createIndex(METHOD_NAME, Vertex.class);
+        // and now this index exist
+        assertThat(tested.getIndices().iterator().hasNext(), Is.is(true));
+    }
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jVertexTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/Neo4jVertexTest.java
@@ -1,0 +1,44 @@
+package com.tinkerpop.blueprints.impls.neo4j;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.kernel.impl.util.FileUtils;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mh
+ * @since 08.01.14
+ */
+public class Neo4jVertexTest {
+
+    private Neo4jGraph graph;
+
+    @Before
+    public void setUp() throws Exception {
+        FileUtils.deleteRecursively(new File("target/test.db"));
+        graph = new Neo4jGraph("target/test.db");
+    }
+
+    @Test
+    public void testVertexLabels() throws Exception {
+        Neo4jVertex vertex = graph.addVertex(null);
+        vertex.addLabel("Label");
+        assertEquals(Arrays.asList("Label"), vertex.getLabels());
+        vertex.addLabel("Label2");
+        assertEquals(Arrays.asList("Label","Label2"), vertex.getLabels());
+        vertex.removeLabel("Label2");
+        assertEquals(Arrays.asList("Label"), vertex.getLabels());
+        vertex.removeLabel("Label");
+        assertEquals(Arrays.<String>asList(), vertex.getLabels());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        graph.shutdown();
+    }
+}

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchGraphTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j/batch/Neo4jBatchGraphTest.java
@@ -1,0 +1,412 @@
+package com.tinkerpop.blueprints.impls.neo4j.batch;
+
+import com.tinkerpop.blueprints.*;
+import com.tinkerpop.blueprints.impls.neo4j.Neo4jGraph;
+import com.tinkerpop.blueprints.util.PropertyFilteredIterable;
+import com.tinkerpop.blueprints.util.io.graphml.GraphMLReader;
+import org.neo4j.index.impl.lucene.LowerCaseKeywordAnalyzer;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class Neo4jBatchGraphTest extends BaseTest {
+
+    public void testFeatureCompliance() {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        System.out.println(batch.getFeatures());
+        batch.getFeatures().checkCompliance();
+        batch.shutdown();
+    }
+
+    public void testAddingVerticesEdges() {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        assertEquals(count(batch.getIndices()), 0); // no indices created
+        final List<Long> ids = new ArrayList<Long>();
+        for (int i = 0; i < 10; i++) {
+            ids.add((Long) batch.addVertex(null).getId());
+        }
+        //System.out.println(ids);
+        for (int i = 1; i < ids.size(); i++) {
+            long idA = ids.get(i - 1);
+            long idB = ids.get(i);
+            //System.out.println(batch.getVertex(idA) + "--" + batch.getVertex(idB));
+            batch.addEdge(null, batch.getVertex(idA), batch.getVertex(idB), idA + "-" + idB);
+        }
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        final Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+        assertEquals(count(graph.getVertices()), 10);
+
+        assertEquals(count(graph.getEdges()), 9);
+        for (final Edge edge : graph.getEdges()) {
+            long idA = (Long) edge.getVertex(Direction.OUT).getId();
+            long idB = (Long) edge.getVertex(Direction.IN).getId();
+            assertEquals(idA + 1, idB);
+            assertEquals(edge.getLabel(), idA + "-" + idB);
+        }
+
+        assertNotNull(graph.getVertex(1L));
+        assertNull(graph.getVertex(100L));
+        assertNull(graph.getEdge(100L));
+        graph.shutdown();
+    }
+
+    public void testAddingVerticesWithUserIdsThenSettingProperties() {
+        List<Long> ids = new ArrayList<Long>(Arrays.asList(100L, 5L, 10L, 4L, 10000L));
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        for (final Long id : ids) {
+            Vertex v = batch.addVertex(id);
+            v.setProperty("theKey", id);
+        }
+        for (final Long id : ids) {
+            assertNotNull(batch.getVertex(id));
+            assertEquals(batch.getVertex(id).getProperty("theKey"), id);
+        }
+        assertNull(batch.getVertex(1L));
+        assertNull(batch.getVertex(2L));
+        assertNull(batch.getVertex(200000L));
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        final Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+        assertEquals(count(graph.getVertices()), ids.size());
+        for (final Long id : ids) {
+            assertNotNull(graph.getVertex(id));
+            assertEquals(graph.getVertex(id).getProperty("theKey"), id);
+            assertEquals(graph.getVertex(id).getPropertyKeys().size(), 1);
+        }
+        assertNull(graph.getVertex(1L));
+        assertNull(graph.getVertex(2L));
+        assertNull(graph.getVertex(200000L));
+        graph.shutdown();
+    }
+
+    public void testAddingVerticesWithUserIdsAsStringsThenSettingProperties() {
+        List<Object> ids = new ArrayList<Object>(Arrays.asList(100L, 5.0d, "10", 4.0f, "10000.00"));
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        for (final Object id : ids) {
+            Vertex v = batch.addVertex(id);
+            v.setProperty("theKey", id);
+        }
+        for (final Object id : ids) {
+            assertNotNull(batch.getVertex(id));
+            assertEquals(batch.getVertex(id).getProperty("theKey"), id);
+        }
+        assertNull(batch.getVertex(1L));
+        assertNull(batch.getVertex(2L));
+        assertNull(batch.getVertex(200000L));
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        final Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+        assertEquals(count(graph.getVertices()), ids.size());
+        assertNotNull(graph.getVertex(100l));
+        assertNotNull(graph.getVertex(5l));
+        assertNotNull(graph.getVertex(10l));
+        assertNotNull(graph.getVertex(4l));
+        assertNotNull(graph.getVertex(10000));
+
+        graph.shutdown();
+
+    }
+
+    public void testAddingVerticesEdgesWithIndices() {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        assertEquals(0, count(batch.getIndices()));
+        batch.createKeyIndex("name", Vertex.class);
+        batch.createKeyIndex("age", Vertex.class);
+        Index<Edge> edgeIndex = batch.createIndex("edgeIdx", Edge.class);
+        assertEquals(1, count(batch.getIndices()));
+
+        for (final Index index : batch.getIndices()) {
+            if (index.getIndexName().equals("edgeIdx")) {
+                assertEquals(index.getIndexClass(), Edge.class);
+            } else {
+                throw new RuntimeException("There should not be another index.");
+            }
+        }
+
+        final List<Long> ids = new ArrayList<Long>();
+        for (int i = 0; i < 10; i++) {
+            final Map<String, Object> map = new HashMap<String, Object>();
+            map.put("name", i + "");
+            map.put("age", i * 10);
+            map.put("nothing", 0);
+            ids.add((Long) batch.addVertex(map).getId());
+        }
+        for (int i = 1; i < ids.size(); i++) {
+            final Map<String, Object> map = new HashMap<String, Object>();
+            map.put("weight", 0.5f);
+            long idA = ids.get(i - 1);
+            long idB = ids.get(i);
+            final Edge edge = batch.addEdge(map, batch.getVertex(idA), batch.getVertex(idB), idA + "-" + idB);
+            edgeIndex.put("unique", idA + "-" + idB, edge);
+            edgeIndex.put("full", "blah", edge);
+        }
+        batch.flushIndices();
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        final Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+
+        assertEquals(count(graph.getIndices()), 1);
+
+        assertEquals(graph.getIndexedKeys(Vertex.class).size(), 2);
+        assertTrue(graph.getIndexedKeys(Vertex.class).contains("name"));
+        assertTrue(graph.getIndexedKeys(Vertex.class).contains("age"));
+        edgeIndex = graph.getIndex("edgeIdx", Edge.class);
+        assertEquals(edgeIndex.getIndexClass(), Edge.class);
+
+        assertEquals(count(graph.getVertices()), 10);
+
+        assertTrue(graph.getVertices("nothing", 0) instanceof PropertyFilteredIterable);
+        assertTrue(graph.getVertices("blah", "blop") instanceof PropertyFilteredIterable);
+        assertFalse(graph.getVertices("name", "marko") instanceof PropertyFilteredIterable); // key index used
+        assertFalse(graph.getVertices("age", 32) instanceof PropertyFilteredIterable); // key indexed used
+
+        for (final Vertex vertex : graph.getVertices()) {
+            int age = (Integer) vertex.getProperty("age");
+            assertEquals(vertex.getProperty("name"), (age / 10) + "");
+
+            assertTrue(graph.getVertices("nothing", 0).iterator().hasNext());
+            assertEquals(count(graph.getVertices("age", age)), 1);
+            assertEquals(graph.getVertices("age", age).iterator().next(), vertex);
+            assertEquals(count(graph.getVertices("name", (age / 10) + "")), 1);
+            assertEquals(graph.getVertices("name", (age / 10) + "").iterator().next(), vertex);
+            assertEquals(vertex.getPropertyKeys().size(), 3);
+            vertex.setProperty("NEW", age);
+            assertEquals(vertex.getPropertyKeys().size(), 4);
+        }
+
+        for (final Vertex vertex : graph.getVertices()) {
+            int age = (Integer) vertex.getProperty("age");
+            assertEquals(vertex.getProperty("NEW"), age);
+            assertEquals(vertex.getPropertyKeys().size(), 4);
+            vertex.removeProperty("NEW");
+        }
+
+        for (final Vertex vertex : graph.getVertices()) {
+            assertNull(vertex.getProperty("NEW"));
+            assertEquals(vertex.getPropertyKeys().size(), 3);
+        }
+
+        assertEquals(count(graph.getEdges()), 9);
+        assertEquals(count(edgeIndex.get("full", "blah")), 9);
+        Set<Edge> edges = new HashSet<Edge>();
+        for (Edge edge : edgeIndex.get("full", "blah")) {
+            edges.add(edge);
+        }
+        assertEquals(edges.size(), 9);
+        for (final Edge edge : graph.getEdges()) {
+            long idA = (Long) edge.getVertex(Direction.OUT).getId();
+            long idB = (Long) edge.getVertex(Direction.IN).getId();
+            assertEquals(idA + 1, idB);
+            assertEquals(edge.getLabel(), idA + "-" + idB);
+            assertEquals(edge.getPropertyKeys().size(), 1);
+            assertEquals(edge.getProperty("weight"), 0.5f);
+
+            assertEquals(edgeIndex.count("weight", 0.5f), 0);
+            assertEquals(edgeIndex.count("unique", idA + "-" + idB), 1);
+            assertEquals(edgeIndex.get("unique", idA + "-" + idB).iterator().next(), edge);
+            assertTrue(edges.contains(edge));
+        }
+
+        graph.shutdown();
+    }
+
+    public void testElementPropertyManipulation() {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        List<Long> vertexIds = new ArrayList<Long>();
+        for (int i = 0; i < 10; i++) {
+            Map<String, Object> map = new HashMap<String, Object>();
+            map.put("a", 1);
+            map.put("b", 2);
+            Vertex vertex = batch.addVertex(map);
+            assertEquals(vertex.getProperty("a"), 1);
+            assertEquals(vertex.getProperty("b"), 2);
+            assertEquals(vertex.getPropertyKeys().size(), 2);
+            vertex.setProperty("b", 3);
+            vertex.setProperty("c", 4);
+            assertEquals(vertex.getProperty("a"), 1);
+            assertEquals(vertex.getProperty("b"), 3);
+            assertEquals(vertex.getProperty("c"), 4);
+            assertEquals(vertex.getPropertyKeys().size(), 3);
+            assertEquals(vertex.removeProperty("a"), 1);
+            assertNull(vertex.getProperty("a"));
+            assertEquals(vertex.getProperty("b"), 3);
+            assertEquals(vertex.getProperty("c"), 4);
+            assertEquals(vertex.getPropertyKeys().size(), 2);
+            vertexIds.add((Long) vertex.getId());
+        }
+        assertEquals(vertexIds.size(), 10);
+
+        List<Long> edgeIds = new ArrayList<Long>();
+        Random random = new Random();
+        for (int i = 0; i < 10; i++) {
+            Edge edge = batch.addEdge(null, batch.getVertex(vertexIds.get(random.nextInt(vertexIds.size()))), batch.getVertex(vertexIds.get(random.nextInt(vertexIds.size()))), "test");
+            edgeIds.add((Long) edge.getId());
+            assertEquals(edge.getPropertyKeys().size(), 0);
+            edge.setProperty("weight", 0.5);
+            assertEquals(edge.getProperty("weight"), 0.5);
+            assertEquals(edge.getPropertyKeys().size(), 1);
+            edge.setProperty("blah", "dah");
+            assertEquals(edge.getPropertyKeys().size(), 2);
+            assertEquals(edge.getProperty("blah"), "dah");
+            edge.setProperty("blah", "blue");
+            assertEquals(edge.getPropertyKeys().size(), 2);
+            assertEquals(edge.getProperty("blah"), "blue");
+            assertEquals(edge.removeProperty("blah"), "blue");
+            assertEquals(edge.getPropertyKeys().size(), 1);
+        }
+
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+        assertEquals(count(graph.getVertices()), 10);
+        for (final Long id : vertexIds) {
+            Vertex vertex = graph.getVertex(id);
+            assertNull(vertex.getProperty("a"));
+            assertEquals(vertex.getProperty("b"), 3);
+            assertEquals(vertex.getProperty("c"), 4);
+            assertEquals(vertex.getPropertyKeys().size(), 2);
+        }
+
+        for (final Long id : edgeIds) {
+            Edge edge = graph.getEdge(id);
+            assertNull(edge.getProperty("blah"));
+            assertEquals(edge.getPropertyKeys().size(), 1);
+            assertEquals(edge.getProperty("weight"), 0.5);
+        }
+        graph.shutdown();
+
+    }
+
+    public void testToStringMethods() {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        System.out.println(batch.createIndex("anIdx", Vertex.class));
+        System.out.println(batch.addVertex(null));
+        System.out.println(batch.addEdge(null, batch.addVertex(null), batch.addVertex(null), "label"));
+        batch.shutdown();
+    }
+
+    public void testGraphMLLoad() throws Exception {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        new GraphMLReader(batch).inputGraph(GraphMLReader.class.getResourceAsStream("graph-example-1.xml"));
+        assertNotNull(batch.getVertex(1));
+        assertNotNull(batch.getVertex(2));
+        assertNotNull(batch.getVertex(3));
+        assertNotNull(batch.getVertex(4));
+        assertNotNull(batch.getVertex(5));
+        assertNotNull(batch.getVertex(6));
+        assertNull(batch.getVertex(7));
+        assertEquals(batch.getVertex(1).getProperty("name"), "marko");
+        assertEquals(batch.getVertex(2).getProperty("name"), "vadas");
+        assertEquals(batch.getVertex(3).getProperty("name"), "lop");
+        assertEquals(batch.getVertex(4).getProperty("name"), "josh");
+        assertEquals(batch.getVertex(5).getProperty("name"), "ripple");
+        assertEquals(batch.getVertex(6).getProperty("name"), "peter");
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+        assertEquals(count(graph.getVertices()), 6);
+        assertEquals(count(graph.getEdges()), 6);
+        assertEquals(count(graph.getVertex("1").getEdges(Direction.OUT)), 3);
+        assertEquals(count(graph.getVertex("1").getEdges(Direction.IN)), 0);
+        Vertex marko = graph.getVertex("1");
+        assertEquals(marko.getProperty("name"), "marko");
+        assertEquals(marko.getProperty("age"), 29);
+        int counter = 0;
+
+        assertEquals(count(graph.getVertex("4").getEdges(Direction.OUT)), 2);
+        assertEquals(count(graph.getVertex("4").getEdges(Direction.IN)), 1);
+        Vertex josh = graph.getVertex("4");
+        assertEquals(josh.getProperty("name"), "josh");
+        assertEquals(josh.getProperty("age"), 32);
+        for (Edge e : graph.getVertex("4").getEdges(Direction.OUT)) {
+            if (e.getVertex(Direction.IN).getId().equals(3l)) {
+                assertEquals(Math.round((Float) e.getProperty("weight")), 0);
+                assertEquals(e.getLabel(), "created");
+                counter++;
+            } else if (e.getVertex(Direction.IN).getId().equals(5l)) {
+                assertEquals(Math.round((Float) e.getProperty("weight")), 1);
+                assertEquals(e.getLabel(), "created");
+                counter++;
+            }
+        }
+        assertEquals(counter, 2);
+        graph.shutdown();
+    }
+
+    public void testIndexParameters() throws Exception {
+        final String directory = this.getWorkingDirectory();
+        final Neo4jBatchGraph batch = new Neo4jBatchGraph(directory);
+        Index<Vertex> index = batch.createIndex("testIdx", Vertex.class, new Parameter("analyzer", LowerCaseKeywordAnalyzer.class.getName()));
+        Vertex a = batch.addVertex(null);
+        a.setProperty("name", "marko");
+        index.put("name", "marko", a);
+        batch.flushIndices();
+        batch.shutdown();
+
+        // native neo4j graph load
+
+        Neo4jGraph graph = new Neo4jGraph(directory);
+        graph.autoStartTransaction();
+        Iterator<Vertex> itty = graph.getIndex("testIdx", Vertex.class).query("name", "*rko").iterator();
+        int counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next().getProperty("name"), "marko");
+        }
+        assertEquals(counter, 1);
+
+        itty = graph.getIndex("testIdx", Vertex.class).query("name", "MaRkO").iterator();
+        counter = 0;
+        while (itty.hasNext()) {
+            counter++;
+            assertEquals(itty.next().getProperty("name"), "marko");
+        }
+        assertEquals(counter, 1);
+
+        graph.shutdown();
+    }
+
+    private String getWorkingDirectory() {
+        String directory = this.computeTestDataRoot().getAbsolutePath();
+        deleteDirectory(new File(directory));
+        return directory;
+    }
+}


### PR DESCRIPTION
- adapted API and SPI changes
- added label support for Neo4jVertext
- added minimal Cypher support to Neo4jGraph (mostly for schema index operations)
- fixed blueprints-tests by adding an constantly open outer transaction which is also restarted after commit or rollback in Neo4jTestGraph
