### PR TITLE
Iterable auto-start transactions...

### DIFF
--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2EdgeIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2EdgeIterable.java
@@ -33,10 +33,12 @@ public class Neo4j2EdgeIterable<T extends Edge> implements CloseableIterable<Neo
             private Relationship nextRelationship = null;
 
             public void remove() {
+                graph.autoStartTransaction(true);
                 this.itty.remove();
             }
 
             public Neo4j2Edge next() {
+                graph.autoStartTransaction(false);
                 if (!checkTransaction) {
                     return new Neo4j2Edge(this.itty.next(), graph);
                 } else {
@@ -60,6 +62,7 @@ public class Neo4j2EdgeIterable<T extends Edge> implements CloseableIterable<Neo
             }
 
             public boolean hasNext() {
+                graph.autoStartTransaction(false);
                 if (!checkTransaction)
                     return this.itty.hasNext();
                 else {

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Vertex.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Vertex.java
@@ -106,6 +106,7 @@ public class Neo4j2Vertex extends Neo4j2Element implements Vertex {
         }
 
         public Iterator<Neo4j2Vertex> iterator() {
+            graph.autoStartTransaction(true);
             final Iterator<Relationship> itty;
             if (labels.length > 0)
                 itty = node.getRelationships(direction, labels).iterator();
@@ -114,14 +115,17 @@ public class Neo4j2Vertex extends Neo4j2Element implements Vertex {
 
             return new Iterator<Neo4j2Vertex>() {
                 public Neo4j2Vertex next() {
+                    graph.autoStartTransaction(false);
                     return new Neo4j2Vertex(itty.next().getOtherNode(node), graph);
                 }
 
                 public boolean hasNext() {
+                    graph.autoStartTransaction(false);
                     return itty.hasNext();
                 }
 
                 public void remove() {
+                    graph.autoStartTransaction(true);
                     itty.remove();
                 }
             };
@@ -146,6 +150,7 @@ public class Neo4j2Vertex extends Neo4j2Element implements Vertex {
         }
 
         public Iterator<Neo4j2Edge> iterator() {
+            graph.autoStartTransaction(true);
             final Iterator<Relationship> itty;
             if (labels.length > 0)
                 itty = node.getRelationships(direction, labels).iterator();
@@ -154,14 +159,17 @@ public class Neo4j2Vertex extends Neo4j2Element implements Vertex {
 
             return new Iterator<Neo4j2Edge>() {
                 public Neo4j2Edge next() {
+                    graph.autoStartTransaction(false);
                     return new Neo4j2Edge(itty.next(), graph);
                 }
 
                 public boolean hasNext() {
+                    graph.autoStartTransaction(false);
                     return itty.hasNext();
                 }
 
                 public void remove() {
+                    graph.autoStartTransaction(true);
                     itty.remove();
                 }
             };

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2VertexIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2VertexIterable.java
@@ -37,6 +37,7 @@ public class Neo4j2VertexIterable<T extends Vertex> implements CloseableIterable
             }
 
             public Neo4j2Vertex next() {
+                graph.autoStartTransaction(false);
                 if (!checkTransaction) {
                     return new Neo4j2Vertex(this.itty.next(), graph);
                 } else {
@@ -58,6 +59,7 @@ public class Neo4j2VertexIterable<T extends Vertex> implements CloseableIterable
             }
 
             public boolean hasNext() {
+                graph.autoStartTransaction(false);
                 if (!checkTransaction)
                     return this.itty.hasNext();
                 else {


### PR DESCRIPTION
The immediate rationale for this PR is that certain Neo4j2 iterables access the underlying graph without automatically starting a transaction (as do other methods on the graph). This scenario was encountered in situations like the following web-service type example:

``` java
@Path("/someResource")
public StreamingResponse getStuff() {
    try {
        return streamingListOfStuff(graph.getVertices());
    } finally {
        graph.getBaseGraph().commit();
    }
}
```

While the `getVertices()` method triggered an auto-start TX, it returned an iterable that when iterated triggered a `NotInTransaction` error if the `streamingListOfStuff` method doesn't explicitly call `graph.autoStartTransaction(false)` before handling the resource. And `streamingListOfStuff` also has to ensure the TX is commited regardless of this change.

**However**, I have doubts that this should be merged as-is. IMHO, if an iterable has some resources attached (i.e. having to close a TX) it should be explicit in the type system, as with `CloseableIterable`. But that would presumably require many more changes. Perhaps someone from Neo4j could advise as to how they handle laziness with read transactions.
