### PR TITLE
Bugfix blueprints-test use of convertId and convertLabel

### DIFF
--- a/blueprints-test/src/main/java/com/tinkerpop/blueprints/EdgeTestSuite.java
+++ b/blueprints-test/src/main/java/com/tinkerpop/blueprints/EdgeTestSuite.java
@@ -472,7 +472,7 @@ public class EdgeTestSuite extends TestSuite {
             for (Edge e : graph.getEdges()) {
                 count++;
                 edgeIds.add(e.getId().toString());
-                assertEquals(graphTest.convertId("test"), e.getLabel());
+                assertEquals(graphTest.convertLabel("test"), e.getLabel());
                 if (e.getId().toString().equals(e1.getId().toString())) {
                     assertEquals(v1, e.getVertex(Direction.OUT));
                     assertEquals(v2, e.getVertex(Direction.IN));
@@ -501,7 +501,7 @@ public class EdgeTestSuite extends TestSuite {
         if (graph.getFeatures().supportsEdgeProperties) {
             Vertex a = graph.addVertex(graphTest.convertId("1"));
             Vertex b = graph.addVertex(graphTest.convertId("2"));
-            Edge edge = graph.addEdge(graphTest.convertId("3"), a, b, "knows");
+            Edge edge = graph.addEdge(graphTest.convertId("3"), a, b, graphTest.convertLabel("knows"));
             assertEquals(edge.getPropertyKeys().size(), 0);
             assertNull(edge.getProperty("weight"));
 
@@ -534,7 +534,7 @@ public class EdgeTestSuite extends TestSuite {
         // fail based on the id or label properties.
         if (graph.getFeatures().supportsEdgeProperties) {
 
-            Edge edge = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "knows");
+            Edge edge = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("knows"));
             try {
                 edge.setProperty("id", "123");
                 fail("Setting edge property with reserved key 'id' should fail");
@@ -575,7 +575,7 @@ public class EdgeTestSuite extends TestSuite {
         // no point in testing graph features for setting string properties because the intent is for it to
         // fail based on the empty key.
         if (graph.getFeatures().supportsEdgeProperties) {
-            final Edge e = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "friend");
+            final Edge e = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("friend"));
             try {
                 e.setProperty("", "value");
                 fail("Setting an edge property with an empty string key should fail");
@@ -613,7 +613,7 @@ public class EdgeTestSuite extends TestSuite {
     public void testSettingBadVertexProperties() {
         final Graph graph = graphTest.generateGraph();
         if (graph.getFeatures().supportsVertexProperties) {
-            Edge edge = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "knows");
+            Edge edge = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("knows"));
             try {
                 edge.setProperty(null, -1);
                 fail("Setting property with a null key should throw an error");

--- a/blueprints-test/src/main/java/com/tinkerpop/blueprints/GraphTestSuite.java
+++ b/blueprints-test/src/main/java/com/tinkerpop/blueprints/GraphTestSuite.java
@@ -450,7 +450,7 @@ public class GraphTestSuite extends TestSuite {
 
         if (graph.getFeatures().supportsEdgeIteration) {
             for (Edge x : graph.getEdges()) {
-                assertEquals(graphTest.convertId("knows"), x.getLabel());
+                assertEquals(graphTest.convertLabel("knows"), x.getLabel());
             }
         }
         if (!graph.getFeatures().ignoresSuppliedIds) {
@@ -482,11 +482,11 @@ public class GraphTestSuite extends TestSuite {
             assertEquals(1, count(a.getEdges(Direction.IN)));
             assertEquals(2, count(a.getEdges(Direction.OUT)));
             for (Edge x : a.getEdges(Direction.OUT)) {
-                assertTrue(x.getLabel().equals(graphTest.convertId("knows")) || x.getLabel().equals(graphTest.convertId("hates")));
+                assertTrue(x.getLabel().equals(graphTest.convertLabel("knows")) || x.getLabel().equals(graphTest.convertLabel("hates")));
             }
-            assertEquals(graphTest.convertId("hates"), i.getLabel());
-            assertEquals(i.getVertex(Direction.IN).getId().toString(), graphTest.convertId("2"));
-            assertEquals(i.getVertex(Direction.OUT).getId().toString(), graphTest.convertId("1"));
+            assertEquals(graphTest.convertLabel("hates"), i.getLabel());
+            assertEquals(i.getVertex(Direction.IN).getId(), graphTest.convertId("2"));
+            assertEquals(i.getVertex(Direction.OUT).getId(), graphTest.convertId("1"));
         }
 
         Set<Object> vertexIds = new HashSet<Object>();
@@ -603,15 +603,15 @@ public class GraphTestSuite extends TestSuite {
         assertEquals(0, count(start.getEdges(Direction.IN)));
         assertEquals(branchSize, count(start.getEdges(Direction.OUT)));
         for (Edge e : start.getEdges(Direction.OUT)) {
-            assertEquals(graphTest.convertId("test1"), e.getLabel());
+            assertEquals(graphTest.convertLabel("test1"), e.getLabel());
             assertEquals(branchSize, count(e.getVertex(Direction.IN).getEdges(Direction.OUT)));
             assertEquals(1, count(e.getVertex(Direction.IN).getEdges(Direction.IN)));
             for (Edge f : e.getVertex(Direction.IN).getEdges(Direction.OUT)) {
-                assertEquals(graphTest.convertId("test2"), f.getLabel());
+                assertEquals(graphTest.convertLabel("test2"), f.getLabel());
                 assertEquals(branchSize, count(f.getVertex(Direction.IN).getEdges(Direction.OUT)));
                 assertEquals(1, count(f.getVertex(Direction.IN).getEdges(Direction.IN)));
                 for (Edge g : f.getVertex(Direction.IN).getEdges(Direction.OUT)) {
-                    assertEquals(graphTest.convertId("test3"), g.getLabel());
+                    assertEquals(graphTest.convertLabel("test3"), g.getLabel());
                     assertEquals(0, count(g.getVertex(Direction.IN).getEdges(Direction.OUT)));
                     assertEquals(1, count(g.getVertex(Direction.IN).getEdges(Direction.IN)));
                 }
@@ -715,7 +715,7 @@ public class GraphTestSuite extends TestSuite {
             if (graph.getFeatures().supportsEdgeIteration) {
                 assertEquals(count(graph.getEdges()), 1);
                 for (Edge edge : graph.getEdges()) {
-                    assertEquals(edge.getLabel(), graphTest.convertId("collaborator"));
+                    assertEquals(edge.getLabel(), graphTest.convertLabel("collaborator"));
                     if (graph.getFeatures().supportsEdgeProperties)
                         assertEquals(edge.getProperty("location"), "internet");
                 }
@@ -749,7 +749,7 @@ public class GraphTestSuite extends TestSuite {
         }
 
         if (graph.getFeatures().supportsEdgeProperties) {
-            Edge e = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "knows");
+            Edge e = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("knows"));
             e.setProperty("string", "friend");
             e.setProperty("double", 1.0d);
 

--- a/blueprints-test/src/main/java/com/tinkerpop/blueprints/IndexTestSuite.java
+++ b/blueprints-test/src/main/java/com/tinkerpop/blueprints/IndexTestSuite.java
@@ -85,8 +85,8 @@ public class IndexTestSuite extends TestSuite {
             printPerformance(graph.toString(), 1, "manual index created", this.stopWatch());
             Vertex v1 = graph.addVertex(null);
             Vertex v2 = graph.addVertex(null);
-            Edge e1 = graph.addEdge(null, v1, v2, "test1");
-            Edge e2 = graph.addEdge(null, v1, v2, "test2");
+            Edge e1 = graph.addEdge(null, v1, v2, graphTest.convertLabel("test1"));
+            Edge e2 = graph.addEdge(null, v1, v2, graphTest.convertLabel("test2"));
             if (graph.getFeatures().supportsEdgeIteration)
                 assertEquals(count(graph.getEdges()), 2);
 

--- a/blueprints-test/src/main/java/com/tinkerpop/blueprints/KeyIndexableGraphTestSuite.java
+++ b/blueprints-test/src/main/java/com/tinkerpop/blueprints/KeyIndexableGraphTestSuite.java
@@ -114,10 +114,10 @@ public class KeyIndexableGraphTestSuite extends TestSuite {
             assertEquals(graph.getIndexedKeys(Edge.class).size(), 1);
             assertTrue(graph.getIndexedKeys(Edge.class).contains("place"));
 
-            Edge e1 = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "knows");
+            Edge e1 = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("knows"));
             e1.setProperty("name", "marko");
             e1.setProperty("place", "everywhere");
-            Edge e2 = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "knows");
+            Edge e2 = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("knows"));
             e2.setProperty("name", "stephen");
             e2.setProperty("place", "everywhere");
 
@@ -143,7 +143,7 @@ public class KeyIndexableGraphTestSuite extends TestSuite {
         }
 
         if (graph.getFeatures().supportsEdgeKeyIndex) {
-            Edge edge = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "knows");
+            Edge edge = graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("knows"));
             edge.setProperty("date", 2012);
             assertEquals(count(graph.getEdges("date", 2012)), 1);
             assertEquals(graph.getEdges("date", 2012).iterator().next(), edge);
@@ -159,7 +159,7 @@ public class KeyIndexableGraphTestSuite extends TestSuite {
         if (graph.getFeatures().supportsEdgeKeyIndex) {
             graph.createKeyIndex("key", Edge.class);
             for (int i = 0; i < 25; i++) {
-                graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), "test").setProperty("key", "value");
+                graph.addEdge(null, graph.addVertex(null), graph.addVertex(null), graphTest.convertLabel("test")).setProperty("key", "value");
             }
             if (graph.getFeatures().supportsVertexIteration) assertEquals(count(graph.getVertices()), 50);
             if (graph.getFeatures().supportsEdgeIteration) assertEquals(count(graph.getEdges()), 25);

--- a/blueprints-test/src/main/java/com/tinkerpop/blueprints/VertexTestSuite.java
+++ b/blueprints-test/src/main/java/com/tinkerpop/blueprints/VertexTestSuite.java
@@ -156,8 +156,8 @@ public class VertexTestSuite extends TestSuite {
 
     public void testGetNonExistantVertices() {
         Graph graph = graphTest.generateGraph();
-        assertNull(graph.getVertex("asbv"));
-        assertNull(graph.getVertex(12.0d));
+        assertNull(graph.getVertex(graphTest.convertId("asbv")));
+        assertNull(graph.getVertex(graphTest.convertId(12.0d)));
         graph.shutdown();
     }
 
@@ -275,8 +275,8 @@ public class VertexTestSuite extends TestSuite {
         Graph graph = graphTest.generateGraph();
         if (graph.getFeatures().supportsVertexProperties) {
 
-            Vertex v1 = graph.addVertex("1");
-            Vertex v2 = graph.addVertex("2");
+            Vertex v1 = graph.addVertex(graphTest.convertId("1"));
+            Vertex v2 = graph.addVertex(graphTest.convertId("2"));
 
             assertNull(v1.removeProperty("key1"));
             assertNull(v1.removeProperty("key2"));
@@ -309,8 +309,8 @@ public class VertexTestSuite extends TestSuite {
             }
 
             if (!graph.getFeatures().ignoresSuppliedIds) {
-                v1 = graph.getVertex("1");
-                v2 = graph.getVertex("2");
+                v1 = graph.getVertex(graphTest.convertId("1"));
+                v2 = graph.getVertex(graphTest.convertId("2"));
 
                 if (graph.getFeatures().supportsStringProperty) {
                     assertEquals("value1", v1.removeProperty("key1"));
@@ -325,8 +325,8 @@ public class VertexTestSuite extends TestSuite {
                 assertNull(v1.removeProperty("key2"));
                 assertNull(v2.removeProperty("key2"));
 
-                v1 = graph.getVertex("1");
-                v2 = graph.getVertex("2");
+                v1 = graph.getVertex(graphTest.convertId("1"));
+                v2 = graph.getVertex(graphTest.convertId("2"));
 
                 if (graph.getFeatures().supportsStringProperty) {
                     v1.setProperty("key1", "value2");

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/impls/TestSuiteConvertTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/impls/TestSuiteConvertTest.java
@@ -1,0 +1,135 @@
+package com.tinkerpop.blueprints.impls;
+
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.EdgeTestSuite;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.GraphTestSuite;
+import com.tinkerpop.blueprints.IndexTestSuite;
+import com.tinkerpop.blueprints.IndexableGraphTestSuite;
+import com.tinkerpop.blueprints.KeyIndexableGraphTestSuite;
+import com.tinkerpop.blueprints.TestSuite;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.VertexTestSuite;
+import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
+
+import java.lang.reflect.Method;
+import java.util.Random;
+
+/**
+ * Tests that the test suites use the GraphTest convertId and convertLabel
+ * methods appropriately.
+ *
+ * @author Christofer Hedbrandh (http://www.knewton.com)
+ */
+public class TestSuiteConvertTest extends GraphTest {
+
+    private static final String ID_PREFIX = "id:";
+    private static final String LABEL_PREFIX = "label:";
+
+
+    public void testVertexTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new VertexTestSuite(this));
+        printTestPerformance("VertexTestSuite", this.stopWatch());
+    }
+
+    public void testEdgeTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new EdgeTestSuite(this));
+        printTestPerformance("EdgeTestSuite", this.stopWatch());
+    }
+
+    public void testGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphTestSuite(this));
+        printTestPerformance("GraphTestSuite", this.stopWatch());
+    }
+
+    public void testKeyIndexableGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new KeyIndexableGraphTestSuite(this));
+        printTestPerformance("KeyIndexableGraphTestSuite", this.stopWatch());
+    }
+
+    public void testIndexableGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new IndexableGraphTestSuite(this));
+        printTestPerformance("IndexableGraphTestSuite", this.stopWatch());
+    }
+
+    public void testIndexTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new IndexTestSuite(this));
+        printTestPerformance("IndexTestSuite", this.stopWatch());
+    }
+
+    public Graph generateGraph() {
+        return generateGraph("");
+    }
+
+    public Graph generateGraph(final String graphDirectoryName) {
+        return new TypeSensitiveTestGraph();
+    }
+
+    public void doTestSuite(final TestSuite testSuite) throws Exception {
+        for (Method method : testSuite.getClass().getDeclaredMethods()) {
+            if (method.getName().startsWith("test")) {
+                System.out.println("Testing " + method.getName() + "...");
+                method.invoke(testSuite);
+            }
+        }
+    }
+
+    @Override
+    public Object convertId(final Object id) {
+        return ID_PREFIX + id.toString();
+    }
+
+    @Override
+    public String convertLabel(final String label) {
+        return LABEL_PREFIX + label;
+    }
+
+    /**
+     * Extension of TinkerGraph that only allows vertex IDs and edge labels
+     * with some prefix. If provided vertex IDs and labels are not on the
+     * required format, an IllegalArgumentException is thrown.
+     */
+    private static class TypeSensitiveTestGraph extends TinkerGraph {
+
+        private static final Random random = new Random();
+
+        @Override
+        public Vertex addVertex(Object id) {
+            if (id == null) {
+                id = ID_PREFIX + random.nextLong();
+            }
+            verifyIdType(id);
+            return super.addVertex(id);
+        }
+
+        @Override
+        public Vertex getVertex(final Object id) {
+            verifyIdType(id);
+            return super.getVertex(id);
+        }
+
+        @Override
+        public Edge addEdge(final Object id, final Vertex outVertex, final Vertex inVertex, final String label) {
+            verifyLabelType(label);
+            return super.addEdge(id, outVertex, inVertex, label);
+        }
+
+        private static void verifyIdType(Object id) {
+            if (id != null && !id.toString().startsWith(ID_PREFIX)) {
+                throw new IllegalArgumentException("ID must start with " + ID_PREFIX);
+            }
+        }
+
+        private static void verifyLabelType(String label) {
+            if (label != null && !label.startsWith(LABEL_PREFIX)) {
+                throw new IllegalArgumentException("Label must start with " + LABEL_PREFIX);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I would have created a pull request for a 2.4.x branch, but you don't seem to be keeping version branches. Ideally I would like to see this change being added to a 2.4.1 version, but since I don't see any previous releases with such minor changes, I wonder, what are the chances of a 2.4.1 version happening you think?

The change addresses a few small fixes of (not) using the convertId() and convertLabel() features in the blueprints-test test suites.
