### PR TITLE
GraphSailConnection: re-using the vertex if the subject is the same as the object

### DIFF
--- a/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSailConnection.java
+++ b/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSailConnection.java
@@ -260,7 +260,12 @@ public class GraphSailConnection extends NotifyingSailConnectionBase implements 
             String c = null == context ? GraphSail.NULL_CONTEXT_NATIVE : store.resourceToNative(context);
 
             Vertex out = getOrCreateVertex(subject);
-            Vertex in = getOrCreateVertex(object);
+            Vertex in;
+            if (subject.equals(object)) {
+                in = out;
+            } else {
+                in = getOrCreateVertex(object);
+            }
             Edge edge = store.graph.addEdge(null, out, in, predicate.stringValue());
             if (inferred) {
                 //System.out.println("inferred!");


### PR DESCRIPTION
What do people think about doing this?

@Lvca @laa It helps me with OrientDB, otherwise I get an error about an inconsistent version on the vertex.

Also I couldn't find direct unit tests for this, are there some that I can add to?
