### PR TITLE
Replaced System.lineSeparator calls with JDK 1.6 compatible equivalents

### DIFF
--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/gml/GMLWriterTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/gml/GMLWriterTest.java
@@ -199,7 +199,7 @@ public class GMLWriterTest extends TestCase {
         System.out.println("working");
         System.setOut(oldStream);
 
-        assertTrue(outContent.toString().endsWith("working" + System.lineSeparator()));
+        assertTrue(outContent.toString().endsWith("working" + System.getProperty("line.separator")));
     }
 
     private int getIterableCount(Iterable<?> elements) {

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/graphml/GraphMLWriterTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/graphml/GraphMLWriterTest.java
@@ -109,6 +109,6 @@ public class GraphMLWriterTest extends TestCase {
         System.out.println("working");
         System.setOut(oldStream);
 
-        assertTrue(outContent.toString().endsWith("working" + System.lineSeparator()));
+        assertTrue(outContent.toString().endsWith("working" + System.getProperty("line.separator")));
     }
 }

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONWriterTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONWriterTest.java
@@ -130,6 +130,6 @@ public class GraphSONWriterTest {
         System.out.println("working");
         System.setOut(oldStream);
 
-        Assert.assertTrue(outContent.toString().endsWith("working" + System.lineSeparator()));
+        Assert.assertTrue(outContent.toString().endsWith("working" + System.getProperty("line.separator")));
     }
 }


### PR DESCRIPTION
java.lang.System.lineSeparator method was added in JDK 1.7.
maven-compiler-plugin in pom.xml is configured to have JDK 1.6 as source and target.
So, the System.lineSeparator calls present in few unit tests do not compile with JDK 1.6.
This patch replaces them with JDK 1.6 equivalents.

So that issues like this do not creep-in in the future, consider also adding enforcer rule to enforce JDK version that build is run on, to match specified compiler source/target.
