### PR TITLE
GraphSailConnection: Tracking the previous subject

### DIFF
--- a/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSailConnection.java
+++ b/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSailConnection.java
@@ -77,6 +77,8 @@ public class GraphSailConnection extends NotifyingSailConnectionBase implements 
     protected void startTransactionInternal() throws SailException {
         statementsAdded = false;
         statementsRemoved = false;
+        prevSubject = null;
+        prevOutVertex = null;
     }
 
     public void commitInternal() throws SailException {
@@ -394,6 +396,8 @@ public class GraphSailConnection extends NotifyingSailConnectionBase implements 
 
         if (0 < edgesToRemove.size()) {
             statementsRemoved = true;
+            prevSubject = null;
+            prevOutVertex = null;
         }
 
         //System.out.println("\tdone removing");
@@ -459,6 +463,8 @@ public class GraphSailConnection extends NotifyingSailConnectionBase implements 
                 }
 
                 statementsRemoved = true;
+                prevSubject = null;
+                prevOutVertex = null;
             }
         }
     }


### PR DESCRIPTION
Data will often list relations for the same subject consecutively.  This sped up inserts when using OrientDB.

Would this be a desired change?  Should it be configurable?
