### PR TITLE
Added missing autoStartTransaction() in getEdges

### DIFF
--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java
@@ -389,6 +389,7 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
     }
 
     public Iterable<Edge> getEdges(final String key, final Object value) {
+        this.autoStartTransaction(false);
         final AutoIndexer indexer = this.rawGraph.index().getRelationshipAutoIndexer();
         if (indexer.isEnabled() && indexer.getAutoIndexedProperties().contains(key))
             return new Neo4j2EdgeIterable(this.rawGraph.index().getRelationshipAutoIndexer().getAutoIndex().get(key, value), this,

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphSpecificTestSuite.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphSpecificTestSuite.java
@@ -182,12 +182,14 @@ public class Neo4j2GraphSpecificTestSuite extends TestSuite {
         Neo4j2Graph graph = (Neo4j2Graph) graphTest.generateGraph();
         Vertex a = graph.addVertex(null);
         Vertex b = graph.addVertex(null);
-        graph.addEdge(null, a, b, "testEdge");
+        Neo4j2Edge edge = graph.addEdge(null, a, b, "testEdge");
+        edge.setProperty("foo", "bar");
         Iterable<Edge> iterable = graph.getEdges();
         graph.commit();
         try {
             assertTrue(iterable.iterator().hasNext());
             assertNotNull(iterable.iterator().next());
+            assertNotNull(graph.getEdges("foo", "bar").iterator().hasNext());
         } catch (NotInTransactionException e) {
             fail("Iterating edge iterable does not auto-start transaction");
         } finally {


### PR DESCRIPTION
After running into #489 I looked at the changeset of #465.

It seems that the call `this.rawGraph.index().getRelationshipAutoIndexer().getAutoIndex().get(key, value)` in [Neo4j2Graph.java line 394](https://github.com/tinkerpop/blueprints/blob/master/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java#L394) caused the `NotInTransactionException` exception.

I added a call to `autoStartTransaction` which fixed the problem for me.

Unfortunately I could not get the test to fail, because it seems that the Indexer is not enabled while executing the tests. Is there any way to enable indexing just for one test?
