### PR TITLE
Adding PartitionKeyIndexableGraph.

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/partition/PartitionKeyIndexableGraph.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/wrappers/partition/PartitionKeyIndexableGraph.java
@@ -1,0 +1,35 @@
+package com.tinkerpop.blueprints.util.wrappers.partition;
+
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.KeyIndexableGraph;
+import com.tinkerpop.blueprints.Parameter;
+import com.tinkerpop.blueprints.util.wrappers.WrapperGraph;
+
+import java.util.Set;
+
+public class PartitionKeyIndexableGraph<T extends KeyIndexableGraph> extends PartitionGraph<T> implements KeyIndexableGraph, WrapperGraph<T> {
+
+    public PartitionKeyIndexableGraph(final T baseGraph, final String partitionKey, final String writePartition, final Set<String> readPartitions) {
+        super(baseGraph, partitionKey, writePartition, readPartitions);
+    }
+
+    public PartitionKeyIndexableGraph(final T baseGraph, final String partitionKey, final String readWritePartition) {
+        super(baseGraph, partitionKey, readWritePartition);
+    }
+
+    @Override
+    public <T extends Element> void dropKeyIndex(String key, Class<T> elementClass) {
+        baseGraph.dropKeyIndex(key, elementClass);
+    }
+
+    @Override
+    public <T extends Element> void createKeyIndex(String key, Class<T> elementClass, Parameter... indexParameters) {
+        // this index needs to be confined to the partition somehow
+        baseGraph.createKeyIndex(key, elementClass, indexParameters);
+    }
+
+    @Override
+    public <T extends Element> Set<String> getIndexedKeys(Class<T> elementClass) {
+        return baseGraph.getIndexedKeys(elementClass);
+    }
+}

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/wrappers/partition/PartitionKeyIndexableGraphTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/wrappers/partition/PartitionKeyIndexableGraphTest.java
@@ -1,0 +1,212 @@
+package com.tinkerpop.blueprints.util.wrappers.partition;
+
+import com.tinkerpop.blueprints.*;
+import com.tinkerpop.blueprints.impls.GraphTest;
+import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
+import com.tinkerpop.blueprints.util.io.gml.GMLReaderTestSuite;
+import com.tinkerpop.blueprints.util.io.graphml.GraphMLReaderTestSuite;
+import com.tinkerpop.blueprints.util.io.graphson.GraphSONReaderTestSuite;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class PartitionKeyIndexableGraphTest extends GraphTest {
+
+    public void testVertexTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new VertexTestSuite(this));
+        printTestPerformance("VertexTestSuite", this.stopWatch());
+    }
+
+    public void testEdgeTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new EdgeTestSuite(this));
+        printTestPerformance("EdgeTestSuite", this.stopWatch());
+    }
+
+    public void testGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphTestSuite(this));
+        printTestPerformance("GraphTestSuite", this.stopWatch());
+    }
+
+    public void testKeyIndexableGraphTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new KeyIndexableGraphTestSuite(this));
+        printTestPerformance("KeyIndexableGraphTestSuite", this.stopWatch());
+    }
+
+    public void testGraphMLReaderTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphMLReaderTestSuite(this));
+        printTestPerformance("GraphMLReaderTestSuite", this.stopWatch());
+    }
+
+    public void testGMLReaderTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GMLReaderTestSuite(this));
+        printTestPerformance("GMLReaderTestSuite", this.stopWatch());
+    }
+
+    public void testGraphSONReaderTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new GraphSONReaderTestSuite(this));
+        printTestPerformance("GraphSONReaderTestSuite", this.stopWatch());
+    }
+
+    public Graph generateGraph() {
+        return generateGraph("");
+    }
+
+    public Graph generateGraph(final String graphDirectoryName) {
+        return new PartitionKeyIndexableGraph<TinkerGraph>(new TinkerGraph(), "_writeGraph", "writeGraph", new HashSet<String>(Arrays.asList("writeGraph")));
+    }
+
+
+    public void doTestSuite(final TestSuite testSuite) throws Exception {
+        for (Method method : testSuite.getClass().getDeclaredMethods()) {
+            if (method.getName().startsWith("test")) {
+                System.out.println("Testing " + method.getName() + "...");
+                method.invoke(testSuite);
+            }
+        }
+    }
+
+    public void testVerticesSeparatedByEdgeInDifferentPartition() {
+        TinkerGraph rawGraph = new TinkerGraph();
+        PartitionKeyIndexableGraph graph = new PartitionKeyIndexableGraph(rawGraph, "_writeGraph", "p1");
+        Vertex inp1 = graph.addVertex("inp1");
+
+        graph.setWritePartition("p2");
+        Vertex inp2 = graph.addVertex("inp2");
+        inp2.setProperty("key","value");
+
+        graph.setWritePartition("p3");
+        graph.addEdge("inp3", inp1, inp2, "links");
+
+        assertNull(graph.getVertex("inp2"));
+        graph.addReadPartition("p2");
+        graph.addReadPartition("p3");
+
+        assertNotNull(graph.getVertex("inp1"));
+        assertNotNull(graph.getVertex("inp2"));
+        assertTrue(graph.getVertex("inp1").getEdges(Direction.OUT).iterator().hasNext());
+
+        graph.removeReadPartition("p2");
+        assertTrue(graph.getVertex("inp1").getEdges(Direction.OUT).iterator().hasNext());
+
+        // the vertex at the end of this traversal is in the p2 partition which was removed above.  it should return
+        // null, throw exception, something....
+        assertNull(graph.getVertex("inp1").getEdges(Direction.OUT).iterator().next().getVertex(Direction.IN));
+    }
+
+    public void testSpecificBehavior() {
+        TinkerGraph rawGraph = new TinkerGraph();
+        PartitionKeyIndexableGraph graph = new PartitionKeyIndexableGraph(rawGraph, "_writeGraph", "a");
+        assertEquals(graph.getReadPartitions().size(), 1);
+        assertTrue(graph.getReadPartitions().contains("a"));
+        assertEquals(graph.getWritePartition(), "a");
+
+        Vertex marko = graph.addVertex(null);
+        Vertex rawMarko = ((PartitionVertex) marko).getBaseVertex();
+        assertEquals(marko.getPropertyKeys().size(), 0);
+        assertEquals(rawMarko.getPropertyKeys().size(), 1);
+        assertNull(marko.getProperty("_writeGraph"));
+        assertEquals(rawMarko.getProperty("_writeGraph"), "a");
+        assertEquals(((PartitionVertex) marko).getPartition(), "a");
+        assertEquals(count(graph.getVertices()), 1);
+        assertEquals(graph.getVertices().iterator().next(), marko);
+        assertEquals(count(graph.getEdges()), 0);
+
+        graph.setWritePartition("b");
+        assertEquals(graph.getReadPartitions().size(), 1);
+        assertTrue(graph.getReadPartitions().contains("a"));
+        assertEquals(graph.getWritePartition(), "b");
+        Vertex peter = graph.addVertex(null);
+        Vertex rawPeter = ((PartitionVertex) peter).getBaseVertex();
+        assertEquals(peter.getPropertyKeys().size(), 0);
+        assertEquals(rawPeter.getPropertyKeys().size(), 1);
+        assertNull(peter.getProperty("_writeGraph"));
+        assertEquals(rawPeter.getProperty("_writeGraph"), "b");
+        assertEquals(((PartitionVertex) peter).getPartition(), "b");
+        assertEquals(count(graph.getVertices()), 1);
+        assertEquals(graph.getVertices().iterator().next(), marko);
+        assertEquals(count(graph.getEdges()), 0);
+
+        graph.removeReadPartition("a");
+        assertEquals(graph.getReadPartitions().size(), 0);
+        assertEquals(graph.getWritePartition(), "b");
+        assertEquals(count(graph.getVertices()), 0);
+        assertEquals(count(graph.getEdges()), 0);
+        graph.addReadPartition("b");
+        assertEquals(graph.getReadPartitions().size(), 1);
+        assertTrue(graph.getReadPartitions().contains("b"));
+        assertEquals(graph.getWritePartition(), "b");
+        assertEquals(count(graph.getVertices()), 1);
+        assertEquals(graph.getVertices().iterator().next(), peter);
+        assertEquals(count(graph.getEdges()), 0);
+
+        graph.addReadPartition("a");
+        assertEquals(graph.getReadPartitions().size(), 2);
+        assertTrue(graph.getReadPartitions().contains("a"));
+        assertTrue(graph.getReadPartitions().contains("b"));
+        assertEquals(graph.getWritePartition(), "b");
+        assertEquals(count(graph.getVertices()), 2);
+        assertEquals(count(graph.getEdges()), 0);
+
+        graph.setWritePartition("c");
+        assertEquals(graph.getReadPartitions().size(), 2);
+        assertTrue(graph.getReadPartitions().contains("a"));
+        assertTrue(graph.getReadPartitions().contains("b"));
+        assertEquals(graph.getWritePartition(), "c");
+        Edge knows = graph.addEdge(null, marko, peter, "knows");
+        Edge rawKnows = ((PartitionEdge) knows).getBaseEdge();
+        assertEquals(count(graph.getVertices()), 2);
+        assertEquals(count(graph.getEdges()), 0);
+        graph.addReadPartition("c");
+        assertEquals(count(graph.getVertices()), 2);
+        assertEquals(count(graph.getEdges()), 1);
+        assertEquals(knows.getPropertyKeys().size(), 0);
+        assertEquals(rawKnows.getPropertyKeys().size(), 1);
+        assertNull(knows.getProperty("_writeGraph"));
+        assertEquals(rawKnows.getProperty("_writeGraph"), "c");
+        assertEquals(((PartitionEdge) knows).getPartition(), "c");
+        assertEquals(graph.getEdges().iterator().next(), knows);
+
+        graph.removeReadPartition("a");
+        graph.removeReadPartition("b");
+        assertEquals(graph.getReadPartitions().size(), 1);
+        assertTrue(graph.getReadPartitions().contains("c"));
+        assertEquals(graph.getWritePartition(), "c");
+        assertEquals(count(graph.getVertices()), 0);
+        assertEquals(count(graph.getEdges()), 1);
+        assertNull(knows.getVertex(Direction.IN));
+        assertNull(knows.getVertex(Direction.OUT));
+
+        // testing indices
+        /*marko.setProperty("name", "marko");
+        peter.setProperty("name", "peter");
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "marko")), 0);
+        graph.addReadPartition("a");
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "marko")), 1);
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "peter")), 0);
+        assertEquals(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "marko").next(), marko);
+        graph.removeReadPartition("a");
+        graph.addReadPartition("b");
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "peter")), 1);
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "marko")), 0);
+        assertEquals(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "peter").next(), peter);
+        graph.addReadPartition("a");
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "peter")), 1);
+        assertEquals(count(graph.getIndex(Index.VERTICES, Vertex.class).get("name", "marko")), 1);
+
+        assertEquals(count(graph.getIndex(Index.EDGES, Edge.class).get("label", "knows")), 1);
+        assertEquals(graph.getIndex(Index.EDGES, Edge.class).get("label", "knows").next(), knows);
+        graph.removeReadPartition("c");
+        assertEquals(count(graph.getIndex(Index.EDGES, Edge.class).get("label", "knows")), 0);
+        */
+
+        graph.shutdown();
+    }
+}


### PR DESCRIPTION
I would like to use both a PartitionGraph and a SailRepository. SailRepository requires a GraphSail which needs a KeyIndexableGraph. There is a PartitionIndexableGraph but no PartitionKeyIndexableGraph.

I have coded up a relatively simple PartitionKeyIndexableGraph (with test). However, I think there needs to be more careful handling around the createIndex. I'd be more than happy to complete this given some guidance.

Thanks. 
