### PR TITLE
Added some checks to ElementHelper

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/ElementHelper.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/ElementHelper.java
@@ -160,8 +160,10 @@ public class ElementHelper {
      * @param properties the properties to set as a Map
      */
     public static void setProperties(final Element element, final Map<String, Object> properties) {
-        for (Map.Entry<String, Object> property : properties.entrySet()) {
-            element.setProperty(property.getKey(), property.getValue());
+       for (Map.Entry<String, Object> property : properties.entrySet()) {
+            if (property.getValue()!=null && !property.getKey().equals("id")) {
+                element.setProperty(property.getKey(), property.getValue());
+            }
         }
     }
 


### PR DESCRIPTION
Checking for null values and excluding the id property which is invalid allows someone to use it like :
BeanMap bm = new BeanMap(activity);
ElementHelper.setProperties(element,bm); 

without worrying about their POJO's properties.
