### PR TITLE
Query caching and prepared statements for SPARQL

### DIFF
--- a/blueprints-core/pom.xml
+++ b/blueprints-core/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-core</artifactId>

--- a/blueprints-graph-jung/pom.xml
+++ b/blueprints-graph-jung/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-graph-jung</artifactId>
@@ -14,7 +14,7 @@
     </description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -34,7 +34,7 @@
             <version>2.0.1</version>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-graph-sail/pom.xml
+++ b/blueprints-graph-sail/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-graph-sail</artifactId>
@@ -13,7 +13,7 @@
     <description>Blueprints property graph ouplementation for Sesame RDF Sail</description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -55,7 +55,7 @@
             <version>${sesame.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>
@@ -91,7 +91,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-neo4j-graph</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>
@@ -104,7 +104,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-sparksee-graph</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-neo4j-graph/pom.xml
+++ b/blueprints-neo4j-graph/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-neo4j-graph</artifactId>
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -37,7 +37,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-neo4j2-graph/pom.xml
+++ b/blueprints-neo4j2-graph/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-neo4j2-graph</artifactId>
@@ -13,7 +13,7 @@
     <description>Blueprints property graph implementation for the Neo4j 2 graph database</description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.tinkerpop.rexster</groupId>
             <artifactId>rexster-core</artifactId>
-            <version>${tinkerpop.version}</version>
+            <version>2.6.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -52,7 +52,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-rexster-graph/pom.xml
+++ b/blueprints-rexster-graph/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-rexster-graph</artifactId>
@@ -13,7 +13,7 @@
     <description>Blueprints property graph implementation for Rexster</description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -23,7 +23,7 @@
             <version>1.4</version>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-sail-graph/pom.xml
+++ b/blueprints-sail-graph/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-sail-graph</artifactId>
@@ -13,7 +13,7 @@
     <description>Blueprints property graph implementation for Sesame RDF Sail</description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -100,7 +100,7 @@
         </dependency>
         <!-- TESTING -->
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-sail-graph/pom.xml
+++ b/blueprints-sail-graph/pom.xml
@@ -17,6 +17,18 @@
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
+        <!-- query caching -->
+        <dependency>
+            <groupId>org.cache2k</groupId>
+            <artifactId>cache2k-api</artifactId>
+            <version>0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cache2k</groupId>
+            <artifactId>cache2k-core</artifactId>
+            <version>0.20</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- SESAME SUPPORT -->
         <dependency>
             <groupId>org.openrdf.sesame</groupId>

--- a/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
+++ b/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
@@ -13,6 +13,9 @@ import com.tinkerpop.blueprints.util.PropertyFilteredIterable;
 import com.tinkerpop.blueprints.util.StringFactory;
 import info.aduna.iteration.CloseableIteration;
 import org.apache.log4j.PropertyConfigurator;
+import org.cache2k.Cache;
+import org.cache2k.CacheBuilder;
+import org.cache2k.CacheSource;
 import org.openrdf.model.Literal;
 import org.openrdf.model.Namespace;
 import org.openrdf.model.Resource;
@@ -50,6 +53,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 /**
@@ -572,12 +576,50 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
      * @throws RuntimeException if an error occurs in the SPARQL query engine
      */
     public List<Map<String, Vertex>> executeSparql(String sparqlQuery) throws RuntimeException {
+        return executeSparql(sparqlQuery, new MapBindingSet());
+    }
+
+    private static class QueryCacheSource implements CacheSource<String, ParsedQuery> {
+        private final SPARQLParser parser = new SPARQLParser();
+        private AtomicInteger parseCount = new AtomicInteger();
+
+        @Override
+        public ParsedQuery get(final String sparqlQuery) throws Throwable {
+            parseCount.incrementAndGet();
+            return parser.parseQuery(sparqlQuery, null);
+        }
+
+        public int cacheMissCount() {
+            return parseCount.get();
+        }
+    }
+    static QueryCacheSource queryCacheSource = new QueryCacheSource();
+    static Cache<String, ParsedQuery> makeCache() {
+        return CacheBuilder.newCache(String.class, ParsedQuery.class).source(queryCacheSource).build();
+    }
+    private static Cache<String, ParsedQuery> queryCache = makeCache();
+
+    private long showCacheMessage = 0;
+    public List<Map<String, Vertex>> executeSparql(String sparqlQuery, final MapBindingSet mapBindingSet) throws RuntimeException {
         try {
             sparqlQuery = getPrefixes() + sparqlQuery;
-            final SPARQLParser parser = new SPARQLParser();
-            final ParsedQuery query = parser.parseQuery(sparqlQuery, null);
+
+            // try to get the parsed query from the cache
+            final ParsedQuery query = queryCache.get(sparqlQuery);
+
+            final long t = System.currentTimeMillis();
+            if(t > showCacheMessage) {
+                LOGGER.info(String.format("Cache misses: %d", queryCacheSource.cacheMissCount()));
+                showCacheMessage = t + 10000;
+            }
+
             boolean includeInferred = false;
-            final CloseableIteration<? extends BindingSet, QueryEvaluationException> results = this.sailConnection.get().evaluate(query.getTupleExpr(), query.getDataset(), new MapBindingSet(), includeInferred);
+            final CloseableIteration<? extends BindingSet, QueryEvaluationException> results =
+                    this.sailConnection.get().evaluate(
+                            query.getTupleExpr(),
+                            query.getDataset(),
+                            mapBindingSet,
+                            includeInferred);
             final List<Map<String, Vertex>> returnList = new ArrayList<Map<String, Vertex>>();
             try {
                 while (results.hasNext()) {

--- a/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
+++ b/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
@@ -581,16 +581,10 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
 
     private static class QueryCacheSource implements CacheSource<String, ParsedQuery> {
         private final SPARQLParser parser = new SPARQLParser();
-        private AtomicInteger parseCount = new AtomicInteger();
 
         @Override
         public ParsedQuery get(final String sparqlQuery) throws Throwable {
-            parseCount.incrementAndGet();
             return parser.parseQuery(sparqlQuery, null);
-        }
-
-        public int cacheMissCount() {
-            return parseCount.get();
         }
     }
     static QueryCacheSource queryCacheSource = new QueryCacheSource();
@@ -599,19 +593,11 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
     }
     private static Cache<String, ParsedQuery> queryCache = makeCache();
 
-    private long showCacheMessage = 0;
     public List<Map<String, Vertex>> executeSparql(String sparqlQuery, final MapBindingSet mapBindingSet) throws RuntimeException {
         try {
             sparqlQuery = getPrefixes() + sparqlQuery;
 
-            // try to get the parsed query from the cache
             final ParsedQuery query = queryCache.get(sparqlQuery);
-
-            final long t = System.currentTimeMillis();
-            if(t > showCacheMessage) {
-                LOGGER.info(String.format("Cache misses: %d", queryCacheSource.cacheMissCount()));
-                showCacheMessage = t + 10000;
-            }
 
             boolean includeInferred = false;
             final CloseableIteration<? extends BindingSet, QueryEvaluationException> results =

--- a/blueprints-sparksee-graph/pom.xml
+++ b/blueprints-sparksee-graph/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-sparksee-graph</artifactId>
@@ -13,7 +13,7 @@
     <description>Blueprints property graph implementation for the Sparksee graph database</description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
@@ -23,7 +23,7 @@
             <version>5.1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${tinkerpop.version}</version>
             <scope>test</scope>

--- a/blueprints-test/pom.xml
+++ b/blueprints-test/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.tinkerpop.blueprints</groupId>
+        <groupId>org.allenai.tinkerpop.blueprints</groupId>
         <artifactId>blueprints</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-test</artifactId>
@@ -13,7 +13,7 @@
     <description>Reusable test suites for Blueprints</description>
     <dependencies>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
+            <groupId>org.allenai.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
-    <groupId>com.tinkerpop.blueprints</groupId>
+    <groupId>org.allenai.tinkerpop.blueprints</groupId>
     <artifactId>blueprints</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <url>http://blueprints.tinkerpop.com</url>
     <name>Blueprints: A Property Graph Model Interface</name>
@@ -25,9 +25,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:tinkerpop/blueprints.git</connection>
-        <developerConnection>scm:git:git@github.com:tinkerpop/blueprints.git</developerConnection>
-        <url>git@github.com:tinkerpop/blueprints.git</url>
+        <connection>scm:git:git@github.com:allenai/blueprints.git</connection>
+        <developerConnection>scm:git:git@github.com:allenai/blueprints.git</developerConnection>
+        <url>git@github.com:allenai/blueprints.git</url>
     </scm>
     <developers>
         <developer>
@@ -60,6 +60,11 @@
             <email>me@matthiasb.com</email>
             <url>http://matthiasb.com</url>
         </developer>
+        <developer>
+            <name>Dirk Groeneveld</name>
+            <email>dirkg@allenai.org</email>
+            <url>http://github.com/dirkgr</url>
+        </developer>
     </developers>
 
     <modules>
@@ -75,7 +80,7 @@
     </modules>
 
     <properties>
-        <tinkerpop.version>2.7.0-SNAPSHOT</tinkerpop.version>
+        <tinkerpop.version>2.7.1-SNAPSHOT</tinkerpop.version>
         <junit.version>4.11</junit.version>
         <ripple.version>1.1</ripple.version>
         <sesame.version>2.7.10</sesame.version>
@@ -133,7 +138,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--<plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.4</version>
@@ -146,7 +151,18 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>-->
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.3</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -169,6 +185,18 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
This change lets you put a parameter map into the `executeSparql()` call, which binds variables to values. This is akin to prepared statements in SQL.

Query parsing is expensive. On our workload, this yields a 44% speedup.