### PR TITLE
Query caching and prepared statements for SPARQL

### DIFF
--- a/blueprints-sail-graph/pom.xml
+++ b/blueprints-sail-graph/pom.xml
@@ -17,6 +17,18 @@
             <artifactId>blueprints-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
+        <!-- query caching -->
+        <dependency>
+            <groupId>org.cache2k</groupId>
+            <artifactId>cache2k-api</artifactId>
+            <version>0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cache2k</groupId>
+            <artifactId>cache2k-core</artifactId>
+            <version>0.20</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- SESAME SUPPORT -->
         <dependency>
             <groupId>org.openrdf.sesame</groupId>

--- a/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
+++ b/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
@@ -13,6 +13,9 @@ import com.tinkerpop.blueprints.util.PropertyFilteredIterable;
 import com.tinkerpop.blueprints.util.StringFactory;
 import info.aduna.iteration.CloseableIteration;
 import org.apache.log4j.PropertyConfigurator;
+import org.cache2k.Cache;
+import org.cache2k.CacheBuilder;
+import org.cache2k.CacheSource;
 import org.openrdf.model.Literal;
 import org.openrdf.model.Namespace;
 import org.openrdf.model.Resource;
@@ -50,6 +53,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 /**
@@ -572,12 +576,50 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
      * @throws RuntimeException if an error occurs in the SPARQL query engine
      */
     public List<Map<String, Vertex>> executeSparql(String sparqlQuery) throws RuntimeException {
+        return executeSparql(sparqlQuery, new MapBindingSet());
+    }
+
+    private static class QueryCacheSource implements CacheSource<String, ParsedQuery> {
+        private final SPARQLParser parser = new SPARQLParser();
+        private AtomicInteger parseCount = new AtomicInteger();
+
+        @Override
+        public ParsedQuery get(final String sparqlQuery) throws Throwable {
+            parseCount.incrementAndGet();
+            return parser.parseQuery(sparqlQuery, null);
+        }
+
+        public int cacheMissCount() {
+            return parseCount.get();
+        }
+    }
+    static QueryCacheSource queryCacheSource = new QueryCacheSource();
+    static Cache<String, ParsedQuery> makeCache() {
+        return CacheBuilder.newCache(String.class, ParsedQuery.class).source(queryCacheSource).build();
+    }
+    private static Cache<String, ParsedQuery> queryCache = makeCache();
+
+    private long showCacheMessage = 0;
+    public List<Map<String, Vertex>> executeSparql(String sparqlQuery, final MapBindingSet mapBindingSet) throws RuntimeException {
         try {
             sparqlQuery = getPrefixes() + sparqlQuery;
-            final SPARQLParser parser = new SPARQLParser();
-            final ParsedQuery query = parser.parseQuery(sparqlQuery, null);
+
+            // try to get the parsed query from the cache
+            final ParsedQuery query = queryCache.get(sparqlQuery);
+
+            final long t = System.currentTimeMillis();
+            if(t > showCacheMessage) {
+                LOGGER.info(String.format("Cache misses: %d", queryCacheSource.cacheMissCount()));
+                showCacheMessage = t + 10000;
+            }
+
             boolean includeInferred = false;
-            final CloseableIteration<? extends BindingSet, QueryEvaluationException> results = this.sailConnection.get().evaluate(query.getTupleExpr(), query.getDataset(), new MapBindingSet(), includeInferred);
+            final CloseableIteration<? extends BindingSet, QueryEvaluationException> results =
+                    this.sailConnection.get().evaluate(
+                            query.getTupleExpr(),
+                            query.getDataset(),
+                            mapBindingSet,
+                            includeInferred);
             final List<Map<String, Vertex>> returnList = new ArrayList<Map<String, Vertex>>();
             try {
                 while (results.hasNext()) {

--- a/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
+++ b/blueprints-sail-graph/src/main/java/com/tinkerpop/blueprints/impls/sail/SailGraph.java
@@ -581,16 +581,10 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
 
     private static class QueryCacheSource implements CacheSource<String, ParsedQuery> {
         private final SPARQLParser parser = new SPARQLParser();
-        private AtomicInteger parseCount = new AtomicInteger();
 
         @Override
         public ParsedQuery get(final String sparqlQuery) throws Throwable {
-            parseCount.incrementAndGet();
             return parser.parseQuery(sparqlQuery, null);
-        }
-
-        public int cacheMissCount() {
-            return parseCount.get();
         }
     }
     static QueryCacheSource queryCacheSource = new QueryCacheSource();
@@ -599,19 +593,11 @@ public class SailGraph implements TransactionalGraph, MetaGraph<Sail> {
     }
     private static Cache<String, ParsedQuery> queryCache = makeCache();
 
-    private long showCacheMessage = 0;
     public List<Map<String, Vertex>> executeSparql(String sparqlQuery, final MapBindingSet mapBindingSet) throws RuntimeException {
         try {
             sparqlQuery = getPrefixes() + sparqlQuery;
 
-            // try to get the parsed query from the cache
             final ParsedQuery query = queryCache.get(sparqlQuery);
-
-            final long t = System.currentTimeMillis();
-            if(t > showCacheMessage) {
-                LOGGER.info(String.format("Cache misses: %d", queryCacheSource.cacheMissCount()));
-                showCacheMessage = t + 10000;
-            }
 
             boolean includeInferred = false;
             final CloseableIteration<? extends BindingSet, QueryEvaluationException> results =


### PR DESCRIPTION
This change lets you put a parameter map into the `executeSparql()` call, which binds variables to values. This is akin to prepared statements in SQL.

Query parsing is expensive. On our workload, this yields a 44% speedup.