### PR TITLE
Added mechanism to decorate GraphSail's DataStore

### DIFF
--- a/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSail.java
+++ b/blueprints-graph-sail/src/main/java/com/tinkerpop/blueprints/oupls/sail/GraphSail.java
@@ -95,7 +95,7 @@ public class GraphSail<T extends KeyIndexableGraph> extends NotifyingSailBase im
 
     private static final String NAMESPACES_VERTEX_ID = "urn:com.tinkerpop.blueprints.pgm.oupls.sail:namespaces";
 
-    private final DataStore store = new DataStore();
+    private final DataStore<T> store;
 
     /**
      * Create a new RDF store using the provided Blueprints graph.  Default edge indices ("p,c,pc") will be used.
@@ -133,6 +133,7 @@ public class GraphSail<T extends KeyIndexableGraph> extends NotifyingSailBase im
      *                        To use GraphSail with a base Graph which does not support edge indices, provide "" as the argument.
      */
     public GraphSail(final T graph, final String indexedPatterns) {
+        store = createStore();
         store.sail = this;
         store.graph = graph;
 
@@ -247,11 +248,15 @@ public class GraphSail<T extends KeyIndexableGraph> extends NotifyingSailBase im
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    protected DataStore<T> createStore() {
+        return new DataStore<T>();
+    }
+
 
     /**
      * A context object which is shared between the Sail and its Connections
      */
-    class DataStore {
+    protected static class DataStore<T extends KeyIndexableGraph> {
         public T graph;
         public NotifyingSailBase sail;
 
@@ -271,7 +276,7 @@ public class GraphSail<T extends KeyIndexableGraph> extends NotifyingSailBase im
 
         public Vertex getReferenceVertex() {
             //System.out.println("value = " + value);
-            Iterable<Vertex> i = store.graph.getVertices(VALUE, NAMESPACES_VERTEX_ID);
+            Iterable<Vertex> i = graph.getVertices(VALUE, NAMESPACES_VERTEX_ID);
             // TODO: restore the close()
             //try {
             Iterator<Vertex> iter = i.iterator();
@@ -309,7 +314,7 @@ public class GraphSail<T extends KeyIndexableGraph> extends NotifyingSailBase im
         }
 
         public Vertex getVertex(final Value value) {
-            for (Vertex v : store.graph.getVertices(VALUE, value.stringValue())) {
+            for (Vertex v : graph.getVertices(VALUE, value.stringValue())) {
                 if (matches(v, value)) {
                     return v;
                 }


### PR DESCRIPTION
Hi there,
This minor change allows one to decorate the DataStore of connections to add capabilities (e.g. caching). Here is an example how I use it:

```scala
trait CachingGraphSail[T <: KeyIndexableGraph] extends GraphSail[T] {
  import CachingGraphSail._

  protected val vertexCacheSize = 10000000

  override def createStore(): DataStore[T] = new DataStore[T] with CachedDataStore[T]

  trait CachedDataStore[T <: KeyIndexableGraph] extends  DataStore[T] {

    val vertexCache = CacheBuilder.newCache(classOf[Value], classOf[Vertex]).
      maxSize(vertexCacheSize).
      eternal(true).
      source(super.getVertex _).
      build()
    
    abstract override def getVertex(value: Value): Vertex = vertexCache.get(value)
  }
}

object CachingGraphSail {
  implicit  def FunctionAsCacheSource[A,B](f: A=>B): CacheSource[A, B] = new CacheSource[A,B] {
    override def get(k: A): B = f(k)
  }
}
```

Best,
Alex