### PR TITLE
Improved osgi packaging and manifest headers.

### DIFF
--- a/blueprints-core/pom.xml
+++ b/blueprints-core/pom.xml
@@ -10,9 +10,21 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-core</artifactId>
-    <url>http://blueprints.tinkerpop.com</url>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-Core</name>
     <description>Core interfaces and utilities for Blueprints</description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.*</osgi.export>
+        <osgi.import>
+            com.carrotsearch.hppc.*;resolution:=optional,
+            com.fasterxml.jackson.*;resolution:=optional,
+            org.codehaus.jettison.json;resolution:=optional,
+            *
+        </osgi.import>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>

--- a/blueprints-graph-jung/pom.xml
+++ b/blueprints-graph-jung/pom.xml
@@ -9,9 +9,16 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-graph-jung</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-GraphJung</name>
     <description>Blueprints property graphs outplementation for the JUNG (Java Universal Network/Graph Framework)
     </description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.oupls.jung.*</osgi.export>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/blueprints-graph-sail/pom.xml
+++ b/blueprints-graph-sail/pom.xml
@@ -9,8 +9,15 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-graph-sail</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-GraphSail</name>
     <description>Blueprints property graph ouplementation for Sesame RDF Sail</description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.oupls.sali.*</osgi.export>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/blueprints-neo4j-graph/pom.xml
+++ b/blueprints-neo4j-graph/pom.xml
@@ -9,8 +9,14 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-neo4j-graph</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-Neo4jGraph</name>
     <description>Blueprints property graph implementation for the Neo4j graph database</description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.impls.neo4j.*</osgi.export>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/blueprints-neo4j2-graph/pom.xml
+++ b/blueprints-neo4j2-graph/pom.xml
@@ -9,11 +9,16 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-neo4j2-graph</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-Neo4j2Graph</name>
     <description>Blueprints property graph implementation for the Neo4j 2 graph database</description>
+
     <properties>
         <neo4j.version>2.1.6</neo4j.version>
+        <osgi.export>com.tinkerpop.blueprints.impls.neo4j2.*</osgi.export>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/blueprints-rexster-graph/pom.xml
+++ b/blueprints-rexster-graph/pom.xml
@@ -9,8 +9,15 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-rexster-graph</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-RexsterGraph</name>
     <description>Blueprints property graph implementation for Rexster</description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.impls.rexster.*</osgi.export>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/blueprints-rexster-graph/src/main/java/com/tinkerpop/blueprints/impls/rexster/RexsterElementIterable.java
+++ b/blueprints-rexster-graph/src/main/java/com/tinkerpop/blueprints/impls/rexster/RexsterElementIterable.java
@@ -2,7 +2,7 @@ package com.tinkerpop.blueprints.impls.rexster;
 
 import com.tinkerpop.blueprints.CloseableIterable;
 import com.tinkerpop.blueprints.Element;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang.NotImplementedException;
 
 import java.util.Iterator;
 import java.util.LinkedList;

--- a/blueprints-sail-graph/pom.xml
+++ b/blueprints-sail-graph/pom.xml
@@ -9,8 +9,15 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-sail-graph</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-SailGraph</name>
     <description>Blueprints property graph implementation for Sesame RDF Sail</description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.impls.sali.*</osgi.export>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/blueprints-sparksee-graph/pom.xml
+++ b/blueprints-sparksee-graph/pom.xml
@@ -9,8 +9,15 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>blueprints-sparksee-graph</artifactId>
+    <packaging>bundle</packaging>
+
     <name>Blueprints-SparkseeGraph</name>
     <description>Blueprints property graph implementation for the Sparksee graph database</description>
+
+    <properties>
+        <osgi.export>com.tinkerpop.blueprints.impls.sparksee.*</osgi.export>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,9 @@
         <sesametools.version>1.8</sesametools.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <osgi.export />
+        <osgi.import>*</osgi.import>
     </properties>
 
     <build>
@@ -133,6 +136,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
             <!--<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -164,6 +172,17 @@
                     <version>2.11</version>
                     <configuration>
                         <runOrder>random</runOrder>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.5.3</version>
+                    <configuration>
+                        <instructions>
+                            <Import-Package>${osgi.import}</Import-Package>
+                            <Export-Package>${osgi.export}</Export-Package>
+                        </instructions>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
By default tinkerpop does not provide OSGi metadata which is just few extra manifest entries. I am open to backport this fix to 2.6.0 if mainanance release is planned.