### PR TITLE
GraphSON

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONUtility.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONUtility.java
@@ -1,21 +1,5 @@
 package com.tinkerpop.blueprints.util.io.graphson;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MappingJsonFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Element;
-import com.tinkerpop.blueprints.Vertex;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
-import org.codehaus.jettison.json.JSONTokener;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Array;
@@ -28,7 +12,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.tinkerpop.blueprints.util.io.graphson.ElementPropertyConfig.ElementPropertiesRule;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.codehaus.jettison.json.JSONTokener;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.io.graphson.ElementPropertyConfig.ElementPropertiesRule;
 
 /**
  * Helps write individual graph elements to TinkerPop JSON format known as GraphSON.
@@ -560,6 +560,8 @@ public class GraphSONUtility {
                             showTypes ? GraphSONMode.EXTENDED : GraphSONMode.NORMAL);
                 } else if (value.getClass().isArray()) {
                     value = createJSONList(convertArrayToList(value), propertyKeys, showTypes);
+                } else if (value instanceof IGraphSONIterable){
+                	value = createJSONList(((IGraphSONIterable)value).getList(), propertyKeys, showTypes);
                 }
             }
 

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONUtility.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONUtility.java
@@ -560,8 +560,8 @@ public class GraphSONUtility {
                             showTypes ? GraphSONMode.EXTENDED : GraphSONMode.NORMAL);
                 } else if (value.getClass().isArray()) {
                     value = createJSONList(convertArrayToList(value), propertyKeys, showTypes);
-                } else if (value instanceof IGraphSONIterable){
-                	value = createJSONList(((IGraphSONIterable)value).getList(), propertyKeys, showTypes);
+                } else if (value instanceof Iterable){
+                	value = createJSONList(getList((Iterable)value), propertyKeys, showTypes);
                 }
             }
 
@@ -570,6 +570,15 @@ public class GraphSONUtility {
         return jsonMap;
 
     }
+    
+	private static List<Element> getList(Iterable<Element> value) {
+		List<Element> result = new ArrayList<Element>();
+		for (Iterator<Element> iterator = value.iterator(); iterator.hasNext();) {
+			Element e = (Element) iterator.next();
+			result.add(e);
+		}
+		return result;
+	}
 
     private static void addObject(final ArrayNode jsonList, final Object value) {
         if (value == null) {

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
@@ -1,9 +1,0 @@
-package com.tinkerpop.blueprints.util.io.graphson;
-
-import java.util.List;
-
-import com.tinkerpop.blueprints.Element;
-
-public interface IGraphSONIterable {
-	public List<? extends Element> getList();
-}

--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
@@ -1,0 +1,9 @@
+package com.tinkerpop.blueprints.util.io.graphson;
+
+import java.util.List;
+
+import com.tinkerpop.blueprints.Element;
+
+public interface IGraphSONIterable {
+	public List<? extends Element> getList();
+}


### PR DESCRIPTION
New Interface IGraphSONIterable

The change allows GraphSONUtility to use any kind of type that implements IGraphSONIterable. In this way not only List, Map, Array or Element, but all the wrapper that implements IGraphSONIterable, such as OrientElementIterable, will return a valid value from the jsonFromElement method.