### PR TITLE
Update to Neo4j 2.2.1

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -15,6 +15,12 @@ h3. Version 2.7.0 (NOT OFFICIALLY RELEASED YET)
 </dependency>
 ```
 
+* Bump Neo4j2Graph to 2.2.1
+* Deprecated @Neo4j2Graph.setCheckElementsInTransaction@, since the rationale behind it -
+  lack of consistency between Neo4j graph data and indexes - no longer applies.
+* Removed @Neo4j2Graph.nodeIsDeleted@ and @Neo4j2Graph.relationshipIsDeleted@ because
+  the Neo4j graph APIs no longer provide this information
+
 h3. Version 2.6.0 (September 17, 2014)
 
 ```xml

--- a/blueprints-neo4j2-graph/pom.xml
+++ b/blueprints-neo4j2-graph/pom.xml
@@ -12,7 +12,7 @@
     <name>Blueprints-Neo4j2Graph</name>
     <description>Blueprints property graph implementation for the Neo4j 2 graph database</description>
     <properties>
-        <neo4j.version>2.1.6</neo4j.version>
+        <neo4j.version>2.2.1</neo4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -37,6 +37,25 @@
             <artifactId>neo4j-management</artifactId>
             <version>${neo4j.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-kernel</artifactId>
+            <version>${neo4j.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-io</artifactId>
+            <version>${neo4j.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.tinkerpop.rexster</groupId>

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java
@@ -18,7 +18,6 @@ import com.tinkerpop.blueprints.util.PropertyFilteredIterable;
 import com.tinkerpop.blueprints.util.StringFactory;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationConverter;
-import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -33,12 +32,8 @@ import org.neo4j.graphdb.index.AutoIndexer;
 import org.neo4j.graphdb.index.RelationshipIndex;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.core.NodeManager;
-import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.tooling.GlobalGraphOperations;
 
-import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.TransactionManager;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -103,9 +98,6 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
         FEATURES.supportsThreadIsolatedTransactions = true;
     }
 
-    private final TransactionManager transactionManager;
-    private final ExecutionEngine cypher;
-
     protected boolean checkElementsInTransaction() {
         if (this.tx.get() == null) {
             return false;
@@ -127,7 +119,12 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
      *
      * @param checkElementsInTransaction check whether an element is in the transaction between
      *                                   returning it
+     *
+     * @deprecated since Blueprints 2.7.0/Neo4j 2.2.x this method is
+     * no longer required since Neo4j indexes no longer return
+     * deleted elements.
      */
+    @Deprecated
     public void setCheckElementsInTransaction(final boolean checkElementsInTransaction) {
         this.checkElementsInTransaction.set(checkElementsInTransaction);
     }
@@ -139,9 +136,6 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
     public Neo4j2Graph(final GraphDatabaseService rawGraph) {
         this.rawGraph = rawGraph;
 
-        transactionManager = ((GraphDatabaseAPI) rawGraph).getDependencyResolver().resolveDependency(TransactionManager.class);
-
-        cypher = new ExecutionEngine(rawGraph);
         init();
     }
 
@@ -152,9 +146,6 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
                 this.rawGraph = builder.setConfig(configuration).newGraphDatabase();
             else
                 this.rawGraph = builder.newGraphDatabase();
-
-            transactionManager = ((GraphDatabaseAPI) rawGraph).getDependencyResolver().resolveDependency(TransactionManager.class);
-            cypher = new ExecutionEngine(rawGraph);
 
             init();
 
@@ -239,7 +230,7 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
     }
 
     private PropertyContainer getGraphProperties() {
-        return ((GraphDatabaseAPI) this.rawGraph).getDependencyResolver().resolveDependency(NodeManager.class).getGraphProperties();
+        return ((GraphDatabaseAPI) this.rawGraph).getDependencyResolver().resolveDependency(NodeManager.class).newGraphProperties();
     }
 
     private void logNotGraphDatabaseAPI() {
@@ -532,7 +523,7 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
         try {
             tx.get().success();
         } finally {
-            tx.get().finish();
+            tx.get().close();
             tx.remove();
         }
     }
@@ -543,13 +534,7 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
         }
 
         try {
-            javax.transaction.Transaction t = transactionManager.getTransaction();
-            if (t == null || t.getStatus() == Status.STATUS_ROLLEDBACK) {
-                return;
-            }
             tx.get().failure();
-        } catch (SystemException e) {
-            throw new RuntimeException(e);
         } finally {
             tx.get().close();
             tx.remove();
@@ -595,13 +580,6 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
     }
 
     public Iterator<Map<String,Object>> query(String query, Map<String,Object> params) {
-        return cypher.execute(query,params==null ? Collections.<String,Object>emptyMap() : params).iterator();
-    }
-
-    public boolean nodeIsDeleted(long nodeId) {
-        return ((AbstractTransactionManager) transactionManager).getTransactionState().nodeIsDeleted(nodeId);
-    }
-    public boolean relationshipIsDeleted(long nodeId) {
-        return ((AbstractTransactionManager) transactionManager).getTransactionState().relationshipIsDeleted(nodeId);
+        return rawGraph.execute(query,params==null ? Collections.<String,Object>emptyMap() : params);
     }
 }

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Graph.java
@@ -98,12 +98,14 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
         FEATURES.supportsThreadIsolatedTransactions = true;
     }
 
+    /**
+     * @deprecated since Blueprints 2.7.0/Neo4j 2.2.x this method is
+     * no longer required since Neo4j indexes no longer return
+     * deleted elements. It will always return false.
+     */
+    @Deprecated
     protected boolean checkElementsInTransaction() {
-        if (this.tx.get() == null) {
-            return false;
-        } else {
-            return this.checkElementsInTransaction.get();
-        }
+        return false;
     }
 
     /**
@@ -351,14 +353,14 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
      */
     public Iterable<Vertex> getVertices() {
         this.autoStartTransaction(false);
-        return new Neo4j2VertexIterable(GlobalGraphOperations.at(rawGraph).getAllNodes(), this, this.checkElementsInTransaction());
+        return new Neo4j2VertexIterable(GlobalGraphOperations.at(rawGraph).getAllNodes(), this);
     }
 
     public Iterable<Vertex> getVertices(final String key, final Object value) {
         this.autoStartTransaction(false);
         final AutoIndexer indexer = this.rawGraph.index().getNodeAutoIndexer();
         if (indexer.isEnabled() && indexer.getAutoIndexedProperties().contains(key))
-            return new Neo4j2VertexIterable(this.rawGraph.index().getNodeAutoIndexer().getAutoIndex().get(key, value), this, this.checkElementsInTransaction());
+            return new Neo4j2VertexIterable(this.rawGraph.index().getNodeAutoIndexer().getAutoIndex().get(key, value), this);
         else
             return new PropertyFilteredIterable<Vertex>(key, value, this.getVertices());
     }
@@ -377,15 +379,14 @@ public class Neo4j2Graph implements TransactionalGraph, IndexableGraph, KeyIndex
      */
     public Iterable<Edge> getEdges() {
         this.autoStartTransaction(false);
-        return new Neo4j2EdgeIterable(GlobalGraphOperations.at(rawGraph).getAllRelationships(), this, this.checkElementsInTransaction());
+        return new Neo4j2EdgeIterable(GlobalGraphOperations.at(rawGraph).getAllRelationships(), this);
     }
 
     public Iterable<Edge> getEdges(final String key, final Object value) {
         this.autoStartTransaction(false);
         final AutoIndexer indexer = this.rawGraph.index().getRelationshipAutoIndexer();
         if (indexer.isEnabled() && indexer.getAutoIndexedProperties().contains(key))
-            return new Neo4j2EdgeIterable(this.rawGraph.index().getRelationshipAutoIndexer().getAutoIndex().get(key, value), this,
-                    this.checkElementsInTransaction());
+            return new Neo4j2EdgeIterable(this.rawGraph.index().getRelationshipAutoIndexer().getAutoIndex().get(key, value), this);
         else
             return new PropertyFilteredIterable<Edge>(key, value, this.getEdges());
     }

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Index.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2Index.java
@@ -64,8 +64,8 @@ public class Neo4j2Index<T extends Neo4j2Element, S extends PropertyContainer> i
         this.graph.autoStartTransaction(false);
         final IndexHits<S> itty = this.rawIndex.get(key, value);
         if (this.indexClass.isAssignableFrom(Neo4j2Vertex.class))
-            return new Neo4j2VertexIterable((Iterable<Node>) itty, this.graph, this.graph.checkElementsInTransaction());
-        return new Neo4j2EdgeIterable((Iterable<Relationship>) itty, this.graph, this.graph.checkElementsInTransaction());
+            return new Neo4j2VertexIterable((Iterable<Node>) itty, this.graph);
+        return new Neo4j2EdgeIterable((Iterable<Relationship>) itty, this.graph);
     }
 
     /**
@@ -79,8 +79,8 @@ public class Neo4j2Index<T extends Neo4j2Element, S extends PropertyContainer> i
         this.graph.autoStartTransaction(false);
         final IndexHits<S> itty = this.rawIndex.query(key, query);
         if (this.indexClass.isAssignableFrom(Neo4j2Vertex.class))
-            return new Neo4j2VertexIterable((Iterable<Node>) itty, this.graph, this.graph.checkElementsInTransaction());
-        return new Neo4j2EdgeIterable((Iterable<Relationship>) itty, this.graph, this.graph.checkElementsInTransaction());
+            return new Neo4j2VertexIterable((Iterable<Node>) itty, this.graph);
+        return new Neo4j2EdgeIterable((Iterable<Relationship>) itty, this.graph);
     }
 
     /**
@@ -94,8 +94,8 @@ public class Neo4j2Index<T extends Neo4j2Element, S extends PropertyContainer> i
         this.graph.autoStartTransaction(false);
         final IndexHits<S> itty = this.rawIndex.query(query);
         if (this.indexClass.isAssignableFrom(Neo4j2Vertex.class))
-            return new Neo4j2VertexIterable((Iterable<Node>) itty, this.graph, this.graph.checkElementsInTransaction());
-        return new Neo4j2EdgeIterable((Iterable<Relationship>) itty, this.graph, this.graph.checkElementsInTransaction());
+            return new Neo4j2VertexIterable((Iterable<Node>) itty, this.graph);
+        return new Neo4j2EdgeIterable((Iterable<Relationship>) itty, this.graph);
     }
 
     /**
@@ -107,20 +107,10 @@ public class Neo4j2Index<T extends Neo4j2Element, S extends PropertyContainer> i
      */
     public long count(final String key, final Object value) {
         this.graph.autoStartTransaction(false);
-        if (!this.graph.checkElementsInTransaction()) {
-            final IndexHits hits = this.rawIndex.get(key, value);
-            final long count = hits.size();
-            hits.close();
-            return count;
-        } else {
-            final CloseableIterable<T> hits = this.get(key, value);
-            long count = 0;
-            for (final T t : hits) {
-                count++;
-            }
-            hits.close();
-            return count;
-        }
+        final IndexHits hits = this.rawIndex.get(key, value);
+        final long count = hits.size();
+        hits.close();
+        return count;
     }
 
     public void remove(final String key, final Object value, final T element) {

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2VertexIterable.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2VertexIterable.java
@@ -15,22 +15,24 @@ public class Neo4j2VertexIterable<T extends Vertex> implements CloseableIterable
 
     private final Iterable<Node> nodes;
     private final Neo4j2Graph graph;
-    private final boolean checkTransaction;
 
+    /**
+     * @deprecated the {@code checkTransaction} parameter is no longer used.
+     */
+    @Deprecated
     public Neo4j2VertexIterable(final Iterable<Node> nodes, final Neo4j2Graph graph, final boolean checkTransaction) {
-        this.graph = graph;
-        this.nodes = nodes;
-        this.checkTransaction = checkTransaction;
+        this(nodes, graph);
     }
 
     public Neo4j2VertexIterable(final Iterable<Node> nodes, final Neo4j2Graph graph) {
-        this(nodes, graph, false);
+        this.nodes = nodes;
+        this.graph = graph;
     }
 
     public Iterator<Neo4j2Vertex> iterator() {
+        graph.autoStartTransaction(false);
         return new Iterator<Neo4j2Vertex>() {
             private final Iterator<Node> itty = nodes.iterator();
-            private Node nextNode = null;
 
             public void remove() {
                 this.itty.remove();
@@ -38,47 +40,12 @@ public class Neo4j2VertexIterable<T extends Vertex> implements CloseableIterable
 
             public Neo4j2Vertex next() {
                 graph.autoStartTransaction(false);
-                if (!checkTransaction) {
-                    return new Neo4j2Vertex(this.itty.next(), graph);
-                } else {
-                    if (null != this.nextNode) {
-                        final Node temp = this.nextNode;
-                        this.nextNode = null;
-                        return new Neo4j2Vertex(temp, graph);
-                    } else {
-                        while (true) {
-                            final Node node = this.itty.next();
-                            try {
-                                if (!graph.nodeIsDeleted(node.getId())) return new Neo4j2Vertex(node, graph);
-                            } catch (final IllegalStateException e) {
-                                // tried to access a node not available to the transaction
-                            }
-                        }
-                    }
-                }
+                return new Neo4j2Vertex(this.itty.next(), graph);
             }
 
             public boolean hasNext() {
                 graph.autoStartTransaction(false);
-                if (!checkTransaction)
-                    return this.itty.hasNext();
-                else {
-                    if (null != this.nextNode)
-                        return true;
-                    else {
-                        while (this.itty.hasNext()) {
-                            final Node node = this.itty.next();
-                            try {
-                                if (!graph.nodeIsDeleted(node.getId())){
-                                    this.nextNode = node;
-                                    return true;
-                                }
-                            } catch (final IllegalStateException e) {
-                            }
-                        }
-                        return false;
-                    }
-                }
+                return this.itty.hasNext();
             }
         };
     }

--- a/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/batch/Neo4j2BatchGraph.java
+++ b/blueprints-neo4j2-graph/src/main/java/com/tinkerpop/blueprints/impls/neo4j2/batch/Neo4j2BatchGraph.java
@@ -170,7 +170,7 @@ public class Neo4j2BatchGraph implements KeyIndexableGraph, IndexableGraph, Meta
         final Set<String> properties = rawAutoIndexer.getAutoIndexedProperties();
         Transaction tx = rawGraphDB.beginTx();
 
-        final PropertyContainer kernel = ((GraphDatabaseAPI) rawGraphDB).getDependencyResolver().resolveDependency(NodeManager.class).getGraphProperties();
+        final PropertyContainer kernel = ((GraphDatabaseAPI) rawGraphDB).getDependencyResolver().resolveDependency(NodeManager.class).newGraphProperties();
         kernel.setProperty(elementClass.getSimpleName() + INDEXED_KEYS_POSTFIX, properties.toArray(new String[properties.size()]));
 
         int count = 0;

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphCypherTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphCypherTest.java
@@ -1,11 +1,11 @@
 package com.tinkerpop.blueprints.impls.neo4j2;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.impl.util.FileUtils;
 
 import java.io.File;
 import java.util.Map;
@@ -21,7 +21,7 @@ public class Neo4j2GraphCypherTest {
 
     @Before
     public void setUp() throws Exception {
-        FileUtils.deleteRecursively(new File("target/test.db"));
+        FileUtils.deleteDirectory(new File("target/test.db"));
         graph = new Neo4j2Graph("target/test.db");
     }
 

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphSpecificTestSuite.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphSpecificTestSuite.java
@@ -11,6 +11,7 @@ import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -195,6 +196,23 @@ public class Neo4j2GraphSpecificTestSuite extends TestSuite {
         } finally {
             graph.shutdown();
         }
+    }
+
+    public void testIteratingDeletedElementsWithoutSCEIT() throws Exception {
+        Neo4j2Graph graph = (Neo4j2Graph) graphTest.generateGraph();
+        Vertex a = graph.addVertex(null);
+        Vertex b = graph.addVertex(null);
+        Neo4j2Edge edge = graph.addEdge(null, a, b, "testEdge");
+        edge.setProperty("foo", "bar");
+        graph.commit();
+        List<Vertex> list1 = asList(graph.getVertices());
+        assertEquals(2, list1.size());
+        assertTrue(asList(graph.getVertices()).contains(a));
+        a.remove();
+        assertFalse(asList(graph.getVertices()).contains(a));
+        assertEquals(1, asList(graph.getVertices()).size());
+        graph.commit();
+        assertEquals(1, asList(graph.getVertices()).size());
     }
 
     public void testHaGraph() throws Exception {

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphTest.java
@@ -117,7 +117,6 @@ public class Neo4j2GraphTest extends GraphTest {
     public Graph generateGraph(final String graphDirectoryName) {
         final String directory = getWorkingDirectory();
         Neo4j2Graph graph = new Neo4j2Graph(directory + "/" + graphDirectoryName);
-        graph.setCheckElementsInTransaction(true);
 
         // for clean shutdown later
         testGraph.set(graph);

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphUsingANonInternalAbstractGraphClassFail.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2GraphUsingANonInternalAbstractGraphClassFail.java
@@ -7,14 +7,15 @@ import org.junit.Test;
 import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.TransactionBuilder;
-import org.neo4j.kernel.impl.nioneo.store.StoreId;
+import org.neo4j.kernel.impl.store.StoreId;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertThat;
 
@@ -24,8 +25,7 @@ public class Neo4j2GraphUsingANonInternalAbstractGraphClassFail {
 
         public GraphDatabaseService getLazy() {
             if (lazy == null) {
-                // load that lazy graph in a unique folder
-                lazy = new GraphDatabaseFactory().newEmbeddedDatabase(getClass().getName() + "/" + System.currentTimeMillis());
+                lazy = new TestGraphDatabaseFactory().newImpermanentDatabase();
             }
             return lazy;
         }
@@ -69,6 +69,21 @@ public class Neo4j2GraphUsingANonInternalAbstractGraphClassFail {
             return getLazy().getAllNodes();
         }
 
+        @Override
+        public ResourceIterator<Node> findNodes(Label label, String s, Object o) {
+            return getLazy().findNodes(label, s, o);
+        }
+
+        @Override
+        public Node findNode(Label label, String s, Object o) {
+            return getLazy().findNode(label, s, o);
+        }
+
+        @Override
+        public ResourceIterator<Node> findNodes(Label label) {
+            return getLazy().findNodes(label);
+        }
+
         /**
          * @return
          * @category delegate
@@ -94,6 +109,16 @@ public class Neo4j2GraphUsingANonInternalAbstractGraphClassFail {
          */
         public Transaction beginTx() {
             return getLazy().beginTx();
+        }
+
+        @Override
+        public Result execute(String s) throws QueryExecutionException {
+            return getLazy().execute(s);
+        }
+
+        @Override
+        public Result execute(String s, Map<String, Object> map) throws QueryExecutionException {
+            return getLazy().execute(s, map);
         }
 
         /**
@@ -196,11 +221,29 @@ public class Neo4j2GraphUsingANonInternalAbstractGraphClassFail {
         }
 
         @Override
-        @Deprecated
-        public TransactionBuilder tx() {
-            return ((GraphDatabaseAPI) getLazy()).tx();
+        public ResourceIterator<Node> findNodes(Label label, String s, Object o) {
+            return ((GraphDatabaseAPI) getLazy()).findNodes(label, s, o);
         }
 
+        @Override
+        public Node findNode(Label label, String s, Object o) {
+            return getLazy().findNode(label, s, o);
+        }
+
+        @Override
+        public ResourceIterator<Node> findNodes(Label label) {
+            return ((GraphDatabaseAPI) getLazy()).findNodes(label);
+        }
+
+        @Override
+        public Result execute(String s) throws QueryExecutionException {
+            return getLazy().execute(s);
+        }
+
+        @Override
+        public Result execute(String s, Map<String, Object> map) throws QueryExecutionException {
+            return getLazy().execute(s, map);
+        }
     }
 
     /**

--- a/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2VertexTest.java
+++ b/blueprints-neo4j2-graph/src/test/java/com/tinkerpop/blueprints/impls/neo4j2/Neo4j2VertexTest.java
@@ -1,9 +1,9 @@
 package com.tinkerpop.blueprints.impls.neo4j2;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.kernel.impl.util.FileUtils;
 
 import java.io.File;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ public class Neo4j2VertexTest {
 
     @Before
     public void setUp() throws Exception {
-        FileUtils.deleteRecursively(new File("target/test.db"));
+        FileUtils.deleteDirectory(new File("target/test.db"));
         graph = new Neo4j2Graph("target/test.db");
     }
 


### PR DESCRIPTION
Since the Neo4j API has changed substantially this involved some significant modifications. The major one is that `setCheckElementsInTransaction` is now a (deprecated) no-op, since it no longer appears possible to determine in a straightforward manner whether a node or relationship has been deleted in a given transaction.

The good news is that the consistency between the graph and legacy index data seems to have been improved, so the indices no longer seem to return deleted nodes/rels.

**Note the following _breaking_ API change:**

The `nodeIsDeleted` and `relationshipIsDeleted` **public** methods on the graph have been actually removed, since:

1. I can't figure out how to implement them
2. They were only used (internally) for checking if elements were in
   a transaction, which is no longer required
3. It's better that people fix code to not depend on these methods than
   for them to do something wrong/misleading/throw an exception

Additionally, fixed various test code.

A note on compatibility: I've tested this on a reasonably substantial project and the only differences I noticed from 2.1.x involved order of relationship iteration, which shouldn't be depended on anyway.

Ref #529.