### PR TITLE
Add check for null InputStream to prevent infinite loop

### DIFF
--- a/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONReader.java
+++ b/blueprints-core/src/main/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONReader.java
@@ -136,6 +136,10 @@ public class GraphSONReader {
     public static void inputGraph(final Graph inputGraph, final InputStream jsonInputStream, int bufferSize,
                                   final Set<String> edgePropertyKeys, final Set<String> vertexPropertyKeys) throws IOException {
 
+        if (jsonInputStream == null) {
+            throw new IllegalArgumentException("InputStream must not be null");
+        }
+
         final JsonParser jp = jsonFactory.createJsonParser(jsonInputStream);
 
         // if this is a transactional graph then we're buffering

--- a/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONReaderTest.java
+++ b/blueprints-test/src/test/java/com/tinkerpop/blueprints/util/io/graphson/GraphSONReaderTest.java
@@ -308,6 +308,13 @@ public class GraphSONReaderTest {
 
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void inputStreamIsNull() throws IOException {
+        TinkerGraph graph = new TinkerGraph();
+        InputStream inputStream = null;
+        GraphSONReader.inputGraph(graph, inputStream);
+    }
+
 
     private int getIterableCount(Iterable elements) {
         int counter = 0;


### PR DESCRIPTION
A null InputStream will cause the GraphSONReader.inputGraph to go into an infinite loop.